### PR TITLE
:rocket: Release 3.0.0

### DIFF
--- a/.github/workflows/3.0.0.yml
+++ b/.github/workflows/3.0.0.yml
@@ -1,0 +1,16 @@
+name: 🚀 Deploy 3.0.0
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    uses: libhal/ci/.github/workflows/deploy.yml@5.x.y
+    with:
+      compiler: gcc
+      version: 3.0.0
+      arch: x86_64
+      compiler_version: 12.3
+      compiler_package: ""
+      os: Linux
+    secrets: inherit


### PR DESCRIPTION
Its too difficult to make all of the requirements work without either globally enabling pre-release usage which can be problematic in the future. So moving to 3.0.0 is the best bet to get the libraries to play nicely with each other.