### PR TITLE
:rotating_light: Add `[[noreturn]]` to safe_throw

### DIFF
--- a/include/libhal/error.hpp
+++ b/include/libhal/error.hpp
@@ -593,7 +593,7 @@ struct unknown : public exception
  * @throw thrown_t - the passed p_thrown_object.
  */
 template<class thrown_t>
-void safe_throw(thrown_t&& p_thrown_object)
+[[noreturn]] void safe_throw(thrown_t&& p_thrown_object)
 {
   static_assert(
     std::is_trivially_destructible_v<thrown_t>,


### PR DESCRIPTION
This will tell the compiler that hal::safe_throw
does not return and thus there is no return value
needed when this function is called.