### PR TITLE
:sparkles: Add create_unique_static_buffer

### DIFF
--- a/.github/workflows/3.3.0.yml
+++ b/.github/workflows/3.3.0.yml
@@ -1,0 +1,16 @@
+name: 🚀 Deploy 3.3.0
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    uses: libhal/ci/.github/workflows/deploy.yml@5.x.y
+    with:
+      compiler: gcc
+      version: 3.3.0
+      arch: x86_64
+      compiler_version: 12.3
+      compiler_package: ""
+      os: Linux
+    secrets: inherit

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ libhal_unit_test(SOURCES
   tests/spi.test.cpp
   tests/adc.test.cpp
   tests/dac.test.cpp
+  tests/initializers.test.cpp
   tests/input_pin.test.cpp
   tests/interrupt_pin.test.cpp
   tests/output_pin.test.cpp

--- a/conanfile.py
+++ b/conanfile.py
@@ -57,7 +57,7 @@ class libhal_conan(ConanFile):
     def build_requirements(self):
         self.tool_requires("cmake/3.27.1")
         self.tool_requires("libhal-cmake-util/[^4.0.5]")
-        self.test_requires("boost-ext-ut/1.1.9")
+        self.test_requires("boost-ext-ut/2.0.1")
 
     def requirements(self):
         self.requires("tl-function-ref/1.0.0")

--- a/include/libhal/initializers.hpp
+++ b/include/libhal/initializers.hpp
@@ -1,7 +1,12 @@
 #pragma once
 
 #include <cstdint>
+
+#include <array>
+#include <span>
 #include <type_traits>
+
+#include "units.hpp"
 
 namespace hal {
 
@@ -215,6 +220,37 @@ inline constexpr channel_t<value> channel{};
  */
 template<std::int64_t value>
 inline constexpr buffer_t<value> buffer{};
+
+/**
+ * @brief Generate a static byte buffer at compile time.
+ *
+ * Each call to this function will generate a new statically allocated buffer
+ * at compile time.
+ *
+ * NEVER: call this function with the template argument set like so:
+ *
+ *        // NEVER DO THIS!
+ *        auto buffer = create_unique_static_buffer<float>();
+ *
+ * This is dangerous because if any other code invoked this function with the
+ * same input type, and the same `p_buffer_size`, it will result in the same
+ * exact instance of the buffer being returned. Having two parts of the code
+ * writing to this buffer is undefined behavior.
+ *
+ * @tparam decltype([]() {}) - Do not modify or set this. This generates a new
+ * type instance each time it is called.
+ * @param p_buffer_size - Buffer parameter type to construct the static array
+ * with.
+ * @return constexpr std::span<hal::byte> - Span pointing to the statically
+ * allocated buffer.
+ */
+template<class = decltype([]() {})>
+constexpr std::span<hal::byte> create_unique_static_buffer(
+  buffer_param auto p_buffer_size)
+{
+  static std::array<hal::byte, p_buffer_size()> buffer{};
+  return buffer;
+}
 
 /// This tag indicates to the reader that the function or constructor used will
 /// perform some runtime sanity checks on its inputs and may return an error or

--- a/tests/initializers.test.cpp
+++ b/tests/initializers.test.cpp
@@ -1,0 +1,120 @@
+// Copyright 2024 Khalil Estell
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <libhal/initializers.hpp>
+
+#include <span>
+
+#include <libhal/error.hpp>
+#include <libhal/serial.hpp>
+#include <libhal/units.hpp>
+
+#include <boost/ut.hpp>
+
+namespace hal {
+namespace {
+struct test_class_allocator
+{
+  test_class_allocator(port_param auto p_port, buffer_param auto p_buffer)
+    : m_buffer(create_unique_static_buffer(p_buffer))
+    , m_port(p_port())
+  {
+    static_assert(0 <= p_port() and p_port() <= 2,
+                  "Supported ports are 0 to 2");
+  }
+
+  // Made public for inspection
+  std::span<hal::byte> m_buffer{};
+  std::uint8_t m_port;
+};
+}  // namespace
+
+void initializers_test()
+{
+  using namespace boost::ut;
+  "create_unique_static_buffer()"_test = []() {
+    // Setup
+    auto span1 = hal::create_unique_static_buffer(buffer<128>);
+    auto span2 = hal::create_unique_static_buffer(buffer<128>);
+    auto span3 = hal::create_unique_static_buffer(buffer<256>);
+    auto span4 = hal::create_unique_static_buffer(buffer<64>);
+    auto span5 = hal::create_unique_static_buffer(buffer<72>);
+
+    test_class_allocator test1(port<2>, buffer<128>);
+    test_class_allocator test2(port<0>, buffer<512>);
+    test_class_allocator test3(port<1>, buffer<128>);
+
+    // Exercise
+    // Verify
+    // Verify: Sizes of each span
+    expect(that % 128 == span1.size());
+    expect(that % 128 == span2.size());
+    expect(that % 256 == span3.size());
+    expect(that % 64 == span4.size());
+    expect(that % 72 == span5.size());
+    expect(that % 128 == test1.m_buffer.size());
+    expect(that % 512 == test2.m_buffer.size());
+    expect(that % 128 == test3.m_buffer.size());
+
+    expect(that % span1.data() == span1.data());
+    expect(that % span1.data() != span2.data());
+    expect(that % span1.data() != span3.data());
+    expect(that % span1.data() != span4.data());
+    expect(that % span1.data() != span5.data());
+    expect(that % span1.data() != test1.m_buffer.data());
+    expect(that % span1.data() != test2.m_buffer.data());
+    expect(that % span1.data() != test3.m_buffer.data());
+
+    expect(that % span2.data() != span1.data());
+    expect(that % span2.data() == span2.data());
+    expect(that % span2.data() != span3.data());
+    expect(that % span2.data() != span4.data());
+    expect(that % span2.data() != span5.data());
+    expect(that % span2.data() != test1.m_buffer.data());
+    expect(that % span2.data() != test2.m_buffer.data());
+    expect(that % span2.data() != test3.m_buffer.data());
+
+    expect(that % span3.data() != span1.data());
+    expect(that % span3.data() != span2.data());
+    expect(that % span3.data() == span3.data());
+    expect(that % span3.data() != span4.data());
+    expect(that % span3.data() != span5.data());
+    expect(that % span3.data() != test1.m_buffer.data());
+    expect(that % span3.data() != test2.m_buffer.data());
+    expect(that % span3.data() != test3.m_buffer.data());
+
+    expect(that % span4.data() != span1.data());
+    expect(that % span4.data() != span2.data());
+    expect(that % span4.data() != span3.data());
+    expect(that % span4.data() == span4.data());
+    expect(that % span4.data() != span5.data());
+    expect(that % span4.data() != test1.m_buffer.data());
+    expect(that % span4.data() != test2.m_buffer.data());
+    expect(that % span4.data() != test3.m_buffer.data());
+
+    expect(that % span5.data() != span1.data());
+    expect(that % span5.data() != span2.data());
+    expect(that % span5.data() != span3.data());
+    expect(that % span5.data() != span4.data());
+    expect(that % span5.data() == span5.data());
+    expect(that % span5.data() != test1.m_buffer.data());
+    expect(that % span5.data() != test2.m_buffer.data());
+    expect(that % span5.data() != test3.m_buffer.data());
+
+    expect(that % test1.m_buffer.data() != test2.m_buffer.data());
+    expect(that % test1.m_buffer.data() != test3.m_buffer.data());
+    expect(that % test2.m_buffer.data() != test3.m_buffer.data());
+  };
+};
+}  // namespace hal

--- a/tests/main.test.cpp
+++ b/tests/main.test.cpp
@@ -33,6 +33,7 @@ extern void g_force_test();
 extern void lengths_test();
 extern void angular_velocity_sensor_test();
 extern void current_sensor_test();
+extern void initializers_test();
 }  // namespace hal
 
 int main()
@@ -43,6 +44,7 @@ int main()
   hal::error_test();
   hal::i2c_test();
   hal::input_pin_test();
+  hal::initializers_test();
   hal::interrupt_pin_test();
   hal::motor_test();
   hal::output_pin_test();


### PR DESCRIPTION
Add generate_static_buffer to initializers.hpp. Allows drivers to generate unique static memory buffers for their drivers using compile time initializer types.