### PR TITLE
:bug: Remove constexpr from create_unique_static_buffer

### DIFF
--- a/include/libhal/initializers.hpp
+++ b/include/libhal/initializers.hpp
@@ -245,7 +245,7 @@ inline constexpr buffer_t<value> buffer{};
  * allocated buffer.
  */
 template<class = decltype([]() {})>
-constexpr std::span<hal::byte> create_unique_static_buffer(
+std::span<hal::byte> create_unique_static_buffer(
   buffer_param auto p_buffer_size)
 {
   static std::array<hal::byte, p_buffer_size()> buffer{};


### PR DESCRIPTION
Fixes an error in deployment.