### PR TITLE
💥 Remove hal::can::settings tq segments from settings

### DIFF
--- a/.github/workflows/4.0.0.yml
+++ b/.github/workflows/4.0.0.yml
@@ -1,0 +1,18 @@
+# Breaking change was removing the bit timing sections from hal::can::settings,
+# now it is just baud_rate.
+name: 🚀 Deploy 4.0.0
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    uses: libhal/ci/.github/workflows/deploy.yml@5.x.y
+    with:
+      compiler: gcc
+      version: 4.0.0
+      arch: x86_64
+      compiler_version: 12.3
+      compiler_package: ""
+      os: Linux
+    secrets: inherit


### PR DESCRIPTION
See issue #40 for the full reasoning and counter options.

This change was decided by me because all other options seemed like they would simply confuse users more than anything else. The project is still young and this would impact very few actual applications, users and libraries. So I decided to cut these additional settings away and bump the version to 4.0.0 for libhal.