### PR TITLE
:sparkles: Add polling_io_waiter()

### DIFF
--- a/.github/workflows/4.2.0.yml
+++ b/.github/workflows/4.2.0.yml
@@ -1,0 +1,18 @@
+# Breaking change was removing the bit timing sections from hal::can::settings,
+# now it is just baud_rate.
+name: 🚀 Deploy 4.2.0
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    uses: libhal/ci/.github/workflows/deploy.yml@5.x.y
+    with:
+      compiler: gcc
+      version: 4.2.0
+      arch: x86_64
+      compiler_version: 12.3
+      compiler_package: ""
+      os: Linux
+    secrets: inherit

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ libhal_unit_test(SOURCES
   tests/temperature_sensor.test.cpp
   tests/servo.test.cpp
   tests/g_force.test.cpp
+  tests/io_waiter.test.cpp
   tests/lengths.test.cpp
   tests/angular_velocity_sensor.test.cpp
   tests/current_sensor.test.cpp

--- a/include/libhal/io_waiter.hpp
+++ b/include/libhal/io_waiter.hpp
@@ -113,4 +113,39 @@ private:
   virtual void driver_wait() = 0;
   virtual void driver_resume() noexcept = 0;
 };
+
+/**
+ * @brief Returns a reference to a statically allocated polling io waiter
+ *
+ * Polling io waiter is a waiter that does nothing. It simply returns when wait
+ * or resume are called, causing the driver to poll its ready flag until it is
+ * completed. This should be used as a default io waiter type for drivers so
+ * the user does not have to manually pass the polling io waiter in the code.
+ * This waiter can be used in applications where polling is an acceptable option
+ * during a driver's waiting period.
+ *
+ * @return io_waiter& - reference to statically allocated polling io waiter
+ * object.
+ */
+inline io_waiter& polling_io_waiter()
+{
+  class polling_io_waiter_t : public hal::io_waiter
+  {
+    void driver_wait()
+    {
+      // Do nothing and allow the outer loop of the driver to poll its ready
+      // flag.
+      return;
+    }
+    void driver_resume() noexcept
+    {
+      // Since wait didn't do anything, neither does resume.
+      return;
+    }
+  };
+
+  static polling_io_waiter_t waiter;
+
+  return waiter;
+}
 }  // namespace hal

--- a/tests/io_waiter.test.cpp
+++ b/tests/io_waiter.test.cpp
@@ -1,0 +1,18 @@
+#include <libhal/io_waiter.hpp>
+
+#include <boost/ut.hpp>
+
+namespace hal {
+void io_waiter_test()
+{
+  using namespace boost::ut;
+  "spin lock waiter test"_test = []() {
+    // Setup
+    hal::io_waiter& test_subject = hal::polling_io_waiter();
+    // Exercise
+    // Verify
+    test_subject.wait();
+    test_subject.resume();
+  };
+}
+}  // namespace hal

--- a/tests/main.test.cpp
+++ b/tests/main.test.cpp
@@ -35,6 +35,7 @@ extern void angular_velocity_sensor_test();
 extern void current_sensor_test();
 extern void initializers_test();
 extern void stream_dac_test();
+extern void io_waiter_test();
 }  // namespace hal
 
 int main()


### PR DESCRIPTION
polling_io_waiter() returns a statically allocated io_waiter which can be used as a default parameter for drivers that accept io_waiter, as well as a stub waiter passed to drivers by the application.

- Add unit tests for polling_io_waiter()
- Add 4.2.0 release yaml