### PR TITLE
:memo: Give more intuitive names to spi settings

### DIFF
--- a/include/libhal/spi.hpp
+++ b/include/libhal/spi.hpp
@@ -83,13 +83,27 @@ public:
     /**
      * @brief The polarity of the pins when the signal is idle
      *
+     * CPOL == 0 == false
+     * CPOL == 1 == true
      */
-    bool clock_idles_high = false;
+    union
+    {
+      bool clock_idles_high = false;
+      bool clock_polarity;
+      bool cpol;
+    };
     /**
      * @brief The phase of the clock signal when communicating
      *
+     * CPHA == 0 == false
+     * CPHA == 1 == true
      */
-    bool data_valid_on_trailing_edge = false;
+    union
+    {
+      bool data_valid_on_trailing_edge = false;
+      bool clock_phase;
+      bool cpha;
+    };
   };
 
   /// Default filler data placed on the bus in place of actual write data when

--- a/tests/spi.test.cpp
+++ b/tests/spi.test.cpp
@@ -25,6 +25,11 @@ constexpr hal::spi::settings expected_settings{
   .clock_idles_high = true,
   .data_valid_on_trailing_edge = true,
 };
+constexpr hal::spi::settings expected_settings2{
+  .clock_rate = 10.0_kHz,
+  .cpol = true,
+  .cpha = false,
+};
 class test_spi : public hal::spi
 {
 public:
@@ -70,6 +75,40 @@ void spi_test()
     expect(that % expected_out.data() == test.m_data_out.data());
     expect(that % expected_in.data() == test.m_data_in.data());
     expect(expected_filler == test.m_filler);
+    expect(expected_settings.clock_rate == test.m_settings.clock_rate);
+    expect(expected_settings.clock_idles_high ==
+           test.m_settings.clock_idles_high);
+    expect(expected_settings.data_valid_on_trailing_edge ==
+           test.m_settings.data_valid_on_trailing_edge);
+    expect(expected_settings.cpol == test.m_settings.cpol);
+    expect(expected_settings.cpha == test.m_settings.cpha);
+    expect(expected_settings.clock_polarity == test.m_settings.clock_polarity);
+    expect(expected_settings.clock_phase == test.m_settings.clock_phase);
+  };
+  "spi interface test: settings2"_test = []() {
+    // Setup
+    test_spi test;
+    std::array<hal::byte, 4> const expected_out{ 'a', 'b' };
+    std::array<hal::byte, 4> expected_in{ '1', '2' };
+    auto const expected_filler = ' ';
+
+    // Exercise
+    test.configure(expected_settings2);
+    test.transfer(expected_out, expected_in, expected_filler);
+
+    // Verify
+    expect(that % expected_out.data() == test.m_data_out.data());
+    expect(that % expected_in.data() == test.m_data_in.data());
+    expect(expected_filler == test.m_filler);
+    expect(expected_settings2.clock_rate == test.m_settings.clock_rate);
+    expect(expected_settings2.cpol == test.m_settings.cpol);
+    expect(expected_settings2.cpha == test.m_settings.cpha);
+    expect(expected_settings2.clock_idles_high ==
+           test.m_settings.clock_idles_high);
+    expect(expected_settings2.data_valid_on_trailing_edge ==
+           test.m_settings.data_valid_on_trailing_edge);
+    expect(expected_settings2.clock_polarity == test.m_settings.clock_polarity);
+    expect(expected_settings2.clock_phase == test.m_settings.clock_phase);
   };
 };
 }  // namespace hal


### PR DESCRIPTION
Use a union to allow multiple names for the same data area. The original names `clock_idles_high` and `data_valid_on_trailing_edge` mean exactly cpol and cpha. But many users do not remember the meaning of these acronym and thus they can get confused. Also, data sheets tend to use the those acronyms over what they really mean. Mapping the labels cpol and cpha to the same memory allows developers to map what is shown in a datasheet with how they configure spi.