### PR TITLE
:sparkles: Add lock interfaces

### DIFF
--- a/.github/workflows/4.3.0.yml
+++ b/.github/workflows/4.3.0.yml
@@ -1,0 +1,18 @@
+# Breaking change was removing the bit timing sections from hal::can::settings,
+# now it is just baud_rate.
+name: 🚀 Deploy 4.3.0
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    uses: libhal/ci/.github/workflows/deploy.yml@5.x.y
+    with:
+      compiler: gcc
+      version: 4.3.0
+      arch: x86_64
+      compiler_version: 12.3
+      compiler_package: ""
+      os: Linux
+    secrets: inherit

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ libhal_unit_test(SOURCES
   tests/angular_velocity_sensor.test.cpp
   tests/current_sensor.test.cpp
   tests/stream_dac.test.cpp
+  tests/lock.test.cpp
   tests/main.test.cpp
 
   PACKAGES

--- a/include/libhal/io_waiter.hpp
+++ b/include/libhal/io_waiter.hpp
@@ -1,3 +1,17 @@
+// Copyright 2024 Khalil Estell
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 namespace hal {

--- a/include/libhal/lock.hpp
+++ b/include/libhal/lock.hpp
@@ -1,3 +1,17 @@
+// Copyright 2024 Khalil Estell
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include "units.hpp"

--- a/include/libhal/lock.hpp
+++ b/include/libhal/lock.hpp
@@ -1,0 +1,139 @@
+#pragma once
+
+#include "units.hpp"
+
+namespace hal {
+/**
+ * @brief Interface for a basic lock satisfying C++'s BasicLockable trait.
+ *
+ */
+class basic_lock
+{
+public:
+  /**
+   * @brief Acquire a lock
+   *
+   * Block the current thread of execution until the lock has been acquired.
+   *
+   */
+  void lock()
+  {
+    return os_lock();
+  }
+
+  /**
+   * @brief Release a lock
+   *
+   */
+  void unlock()
+  {
+    return os_unlock();
+  }
+
+  virtual ~basic_lock() = default;
+
+private:
+  virtual void os_lock() = 0;
+  virtual void os_unlock() = 0;
+};
+
+/**
+ * @brief Interface for a lock satisfying C++'s Lockable trait.
+ *
+ */
+class pollable_lock : public basic_lock
+{
+public:
+  /**
+   * @brief Attempt to acquire a lock
+   *
+   * This call will not block the current thread of execution.
+   *
+   * @return true - if the lock has been acquired
+   * @return false - if the lock could not be acquired
+   */
+  bool try_lock()
+  {
+    return os_try_lock();
+  }
+
+  virtual ~pollable_lock() = default;
+
+private:
+  virtual bool os_try_lock() = 0;
+};
+
+/**
+ * @brief Interface for a timed lock satisfying C++'s TimedLockable trait.
+ *
+ */
+class timed_lock : public pollable_lock
+{
+public:
+  /**
+   * @brief Attempt to acquire a lock and block for a duration of time.
+   *
+   * This call will block for the supplied amount of time and then return a
+   * status on whether or not the lock was acquired.
+   *
+   * @param p_duration - the amount of time to block the current thread waiting
+   * for the lock to be acquired. Note that the precision of the lock's timing
+   * mechanism may not be as precise as the time duration. Expect the time
+   * duration that the thread blocks for to be the rounded down to the nearest
+   * precision unit of time. For example, if the precision of the system that
+   * manages the lock is 1ms, then providing 2.5ms will result in 2ms waited.
+   * @return true - if the lock was acquired in the time provided.
+   * @return false - if the lock was not acquired in the time provided.
+   */
+  bool try_lock_for(hal::time_duration p_duration)
+  {
+    return os_try_lock_for(p_duration);
+  }
+
+  virtual ~timed_lock() = default;
+
+private:
+  virtual bool os_try_lock_for(hal::time_duration p_duration) = 0;
+};
+
+/**
+ * @brief concept for basic_lockable
+ *
+ * @tparam Lock - lock type
+ */
+template<class Lock>
+concept basic_lockable = requires(Lock lockable) {
+  { lockable.lock() } -> std::same_as<void>;
+  { lockable.unlock() } -> std::same_as<void>;
+};
+
+// concept for lockable which extends basic_lockable
+
+/**
+ * @brief concept for lockable which extends basic_lockable
+ *
+ * @tparam Lock - lock type
+ */
+template<class Lock>
+concept lockable = basic_lockable<Lock> && requires(Lock lockable) {
+  { lockable.try_lock() } -> std::same_as<bool>;
+};
+
+/**
+ * @brief concept for timed_lockable which extends lockable
+ *
+ * @tparam Lock - lock type
+ */
+template<class Lock>
+concept timed_lockable =
+  lockable<Lock> && requires(Lock lockable, hal::time_duration duration) {
+    { lockable.try_lock_for(duration) } -> std::same_as<bool>;
+  };
+
+// static asserts to check conformance to the concepts
+static_assert(basic_lockable<basic_lock>,
+              "basic_lock must satisfy basic_lockable");
+static_assert(lockable<pollable_lock>, "pollable_lock must satisfy lockable");
+static_assert(timed_lockable<timed_lock>,
+              "timed_lock must satisfy timed_lockable");
+}  // namespace hal

--- a/test_package/main.cpp
+++ b/test_package/main.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <cstdio>
-#include <system_error>
 
 #include <libhal/error.hpp>
 #include <libhal/pwm.hpp>
@@ -34,8 +33,6 @@ private:
   {
     std::printf("duty cycle = %f %%\n", p_position);
   }
-
-  int m_error_count_down = 2;
 };
 
 int main()
@@ -50,7 +47,7 @@ int main()
     pwm.duty_cycle(-0.25);
     pwm.duty_cycle(-1.0);
     pwm.frequency(10.0_MHz);
-  } catch (const hal::argument_out_of_domain& p_errc) {
+  } catch (hal::argument_out_of_domain const& p_errc) {
     std::printf("Caught argument_out_of_domain error successfully!\n");
     std::printf("    Object address: %p\n", p_errc.instance());
   } catch (...) {

--- a/tests/helpers.cpp
+++ b/tests/helpers.cpp
@@ -1,3 +1,17 @@
+// Copyright 2024 Khalil Estell
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <cmath>
 
 #include "helpers.hpp"

--- a/tests/io_waiter.test.cpp
+++ b/tests/io_waiter.test.cpp
@@ -1,3 +1,17 @@
+// Copyright 2024 Khalil Estell
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <libhal/io_waiter.hpp>
 
 #include <boost/ut.hpp>

--- a/tests/lock.test.cpp
+++ b/tests/lock.test.cpp
@@ -1,0 +1,290 @@
+// Copyright 2024 Khalil Estell
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <libhal/lock.hpp>
+
+#include <mutex>
+
+#include <libhal/error.hpp>
+
+#include <boost/ut.hpp>
+
+namespace hal {
+namespace {
+struct timed_lock_impl : public hal::timed_lock
+{
+  // Publicly available for inspection and modification
+  bool lock_acquired = false;
+  hal::time_duration duration{ 0 };
+  bool allow_lock_to_be_acquired = true;
+
+private:
+  void os_lock() override
+  {
+    lock_acquired = true;
+  }
+  void os_unlock() override
+  {
+    lock_acquired = false;
+  }
+  bool os_try_lock() override
+  {
+    if (allow_lock_to_be_acquired) {
+      lock_acquired = true;
+    } else {
+      lock_acquired = false;
+    }
+    return lock_acquired;
+  }
+  bool os_try_lock_for(hal::time_duration p_duration) override
+  {
+    duration = p_duration;
+    if (allow_lock_to_be_acquired) {
+      lock_acquired = true;
+    } else {
+      lock_acquired = false;
+    }
+    return lock_acquired;
+  }
+};
+}  // namespace
+
+void lock_test()
+{
+  using namespace boost::ut;
+
+  "lock"_test = []() {
+    // Setup
+    timed_lock_impl test_subject;
+    hal::timed_lock& timed_lock_ref = test_subject;
+    hal::pollable_lock& pollable_lock_ref = test_subject;
+    hal::basic_lock& basic_lock_ref = test_subject;
+    test_subject.lock_acquired = false;
+
+    /* Exercise */ {
+      test_subject.lock();
+      // Verify
+      expect(that % test_subject.lock_acquired);
+    }
+
+    test_subject.lock_acquired = false;
+
+    /* Exercise */ {
+      timed_lock_ref.lock();
+      // Verify
+      expect(that % test_subject.lock_acquired);
+    }
+
+    /* Exercise */ {
+      pollable_lock_ref.lock();
+      // Verify
+      expect(that % test_subject.lock_acquired);
+    }
+
+    test_subject.lock_acquired = false;
+
+    /* Exercise */ {
+      basic_lock_ref.lock();
+      // Verify
+      expect(that % test_subject.lock_acquired);
+    }
+  };
+
+  "unlock"_test = []() {
+    // Setup
+    timed_lock_impl test_subject;
+    hal::timed_lock& timed_lock_ref = test_subject;
+    hal::pollable_lock& pollable_lock_ref = test_subject;
+    hal::basic_lock& basic_lock_ref = test_subject;
+    test_subject.lock_acquired = true;
+
+    /* Exercise */ {
+      test_subject.unlock();
+      // Verify
+      expect(that % not test_subject.lock_acquired);
+    }
+
+    test_subject.lock_acquired = true;
+
+    /* Exercise */ {
+      timed_lock_ref.unlock();
+      // Verify
+      expect(that % not test_subject.lock_acquired);
+    }
+
+    /* Exercise */ {
+      pollable_lock_ref.unlock();
+      // Verify
+      expect(that % not test_subject.lock_acquired);
+    }
+
+    test_subject.lock_acquired = true;
+
+    /* Exercise */ {
+      basic_lock_ref.unlock();
+      // Verify
+      expect(that % not test_subject.lock_acquired);
+    }
+  };
+
+  "try_lock"_test = []() {
+    // Setup
+    timed_lock_impl test_subject;
+    hal::timed_lock& timed_lock_ref = test_subject;
+    hal::pollable_lock& pollable_lock_ref = test_subject;
+    test_subject.lock_acquired = false;
+    test_subject.allow_lock_to_be_acquired = true;
+
+    /* Exercise */ {
+      auto got_lock = test_subject.try_lock();
+      // Verify
+      expect(that % test_subject.lock_acquired);
+      expect(that % got_lock);
+    }
+
+    test_subject.lock_acquired = false;
+
+    /* Exercise */ {
+      auto got_lock = timed_lock_ref.try_lock();
+      // Verify
+      expect(that % test_subject.lock_acquired);
+      expect(that % got_lock);
+    }
+
+    /* Exercise */ {
+      auto got_lock = pollable_lock_ref.try_lock();
+      // Verify
+      expect(that % test_subject.lock_acquired);
+      expect(that % got_lock);
+    }
+
+    test_subject.lock_acquired = false;
+    test_subject.allow_lock_to_be_acquired = false;
+
+    /* Exercise */ {
+      auto got_lock = test_subject.try_lock();
+      // Verify
+      expect(that % not test_subject.lock_acquired);
+      expect(that % not got_lock);
+    }
+
+    /* Exercise */ {
+      auto got_lock = timed_lock_ref.try_lock();
+      // Verify
+      expect(that % not test_subject.lock_acquired);
+      expect(that % not got_lock);
+    }
+
+    /* Exercise */ {
+      auto got_lock = pollable_lock_ref.try_lock();
+      // Verify
+      expect(that % not test_subject.lock_acquired);
+      expect(that % not got_lock);
+    }
+  };
+
+  "try_lock_for"_test = []() {
+    // Setup
+    using namespace std::chrono_literals;
+    timed_lock_impl test_subject;
+    hal::timed_lock& timed_lock_ref = test_subject;
+    test_subject.lock_acquired = false;
+    test_subject.allow_lock_to_be_acquired = true;
+
+    /* Exercise */ {
+      auto got_lock = test_subject.try_lock_for(5ms);
+      // Verify
+      expect(that % test_subject.lock_acquired);
+      expect(that % got_lock);
+      expect(that % 5ms == test_subject.duration);
+    }
+
+    test_subject.lock_acquired = false;
+
+    /* Exercise */ {
+      auto got_lock = timed_lock_ref.try_lock_for(10ms);
+      // Verify
+      expect(that % test_subject.lock_acquired);
+      expect(that % got_lock);
+      expect(that % 10ms == test_subject.duration);
+    }
+
+    test_subject.lock_acquired = false;
+    test_subject.allow_lock_to_be_acquired = false;
+
+    /* Exercise */ {
+      auto got_lock = test_subject.try_lock_for(15ms);
+      // Verify
+      expect(that % not test_subject.lock_acquired);
+      expect(that % not got_lock);
+      expect(that % 15ms == test_subject.duration);
+    }
+
+    /* Exercise */ {
+      auto got_lock = timed_lock_ref.try_lock_for(20ms);
+      // Verify
+      expect(that % not test_subject.lock_acquired);
+      expect(that % not got_lock);
+      expect(that % 20ms == test_subject.duration);
+    }
+  };
+
+  "Usage w/ std::lock_guard<hal::basic_lock>"_test = []() {
+    // Setup
+    timed_lock_impl test_subject;
+    hal::basic_lock& basic_lock_ref = test_subject;
+    hal::pollable_lock& pollable_lock_ref = test_subject;
+    hal::timed_lock& timed_lock_ref = test_subject;
+    test_subject.lock_acquired = false;
+
+    /* Exercise */ {
+      expect(that % not test_subject.lock_acquired);
+      std::lock_guard my_lock(test_subject);
+      // Verify
+      expect(that % test_subject.lock_acquired);
+    }
+    expect(that % not test_subject.lock_acquired);
+
+    test_subject.lock_acquired = false;
+
+    /* Exercise */ {
+      expect(that % not test_subject.lock_acquired);
+      std::lock_guard my_lock(basic_lock_ref);
+      // Verify
+      expect(that % test_subject.lock_acquired);
+    }
+    expect(that % not test_subject.lock_acquired);
+
+    test_subject.lock_acquired = false;
+
+    /* Exercise */ {
+      expect(that % not test_subject.lock_acquired);
+      std::lock_guard my_lock(pollable_lock_ref);
+      // Verify
+      expect(that % test_subject.lock_acquired);
+    }
+    expect(that % not test_subject.lock_acquired);
+
+    test_subject.lock_acquired = false;
+
+    /* Exercise */ {
+      expect(that % not test_subject.lock_acquired);
+      std::lock_guard my_lock(timed_lock_ref);
+      // Verify
+      expect(that % test_subject.lock_acquired);
+    }
+    expect(that % not test_subject.lock_acquired);
+  };
+};
+}  // namespace hal

--- a/tests/main.test.cpp
+++ b/tests/main.test.cpp
@@ -36,6 +36,7 @@ extern void current_sensor_test();
 extern void initializers_test();
 extern void stream_dac_test();
 extern void io_waiter_test();
+extern void lock_test();
 }  // namespace hal
 
 int main()
@@ -62,4 +63,6 @@ int main()
   hal::angular_velocity_sensor_test();
   hal::current_sensor_test();
   hal::stream_dac_test();
+  hal::io_waiter_test();
+  hal::lock_test();
 }


### PR DESCRIPTION
- Add `hal::basic_lock` and its concept `hal::basic_lockable`
- Add `hal::pollable_lock` and its concept `hal::lockable`
- Add `hal::timed_lock` and its concept `hal::timed_lockable`
- Tests to exercise all apis by using an implementation that satisfies `hal::timed_lockable`.