### PR TITLE
:sparkles: Improved interfaces for i2c, serial, & can

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,8 @@ libhal_unit_test(SOURCES
   tests/stream_dac.test.cpp
   tests/lock.test.cpp
   tests/experimental/usb.test.cpp
+  tests/zero_copy_serial.test.cpp
+  tests/buffered_can.test.cpp
   tests/main.test.cpp
 
   PACKAGES

--- a/include/libhal/buffered_can.hpp
+++ b/include/libhal/buffered_can.hpp
@@ -1,0 +1,247 @@
+// Copyright 2024 Khalil Estell
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+#include <array>
+#include <span>
+
+#include "units.hpp"
+
+namespace hal {
+
+/**
+ * @brief Can message ID type trait
+ *
+ */
+using can_id = std::uint32_t;
+
+/**
+ * @brief A standard CAN message
+ *
+ */
+struct can_message
+{
+  /**
+   * @brief ID of the message
+   *
+   */
+  can_id id;
+  /**
+   * @brief Message data contents
+   *
+   */
+  std::array<hal::byte, 8> payload{};
+  /**
+   * @brief The number of valid elements in the payload
+   *
+   * Can be between 0 and 8. A length value above 8 should be considered
+   * invalid and can be discarded.
+   */
+  uint8_t length = 0;
+  /**
+   * @brief Determines if the message is a remote request frame
+   *
+   * If true, then length and payload are ignored.
+   */
+  bool is_remote_request = false;
+};
+
+/**
+ * @brief Generic settings for a can peripheral
+ *
+ */
+struct can_settings
+{
+  /**
+   * @brief Bus clock rate in hertz
+   *
+   * CAN Bit Quanta Timing Diagram of:
+   *
+   *                               | <--- sjw ---> |
+   *         ____    ______    __________    __________
+   *      _/ SYNC \/  PROP  \/   PHASE1   \/   PHASE2   \_
+   *       \______/\________/\____________/\____________/
+   *                                       ^ Sample point
+   *
+   * A can bus bit is separated into the segments:
+   *
+   *   - Sync Segment (always 1qt): Initial sync transition, the start of a
+   *     CAN bit.
+   *   - Propagation Delay (1qt ... 8qt): Number of time quanta to
+   *     compensate for signal/propagation delays across the network.
+   *   - Phase Segment 1 (1qt ... 8qt): phase segment 1 acts as a buffer that
+   *     can be lengthened to resynchronize with the bit stream via the
+   *     synchronization jump width.
+   *   - Phase Segment 2 (1qt ... 8qt): Occurs after the sampling point. Phase
+   *     segment 2. can be shortened to resynchronize with the bit stream via
+   *     the synchronization jump width.
+   *   - Synchronization jump width (1qt ... 4qt): This is the maximum time by
+   *     which the bit sampling period may be lengthened or shortened during
+   *     each cycle to adjust for oscillator mismatch between nodes. This
+   *     value must be smaller than phase_segment1 and phase_segment2.
+   *
+   * The exact value of these segments is calculated for you by the can
+   * peripheral based on the input clock to the peripheral and the desired
+   * baud rate.
+   *
+   * A conformant can bus peripheral driver will either choose from tq
+   * starting from 25 and reducing it down to 8 or will have pre-configured
+   * timing values for each frequency it supports.
+   *
+   */
+  hertz baud_rate = 100.0_kHz;
+};
+
+/**
+ * @brief Controller Area Network (CAN bus) hardware abstraction interface with
+ * message buffering.
+ *
+ * Buffered can provides easy access to all can messages received by the CAN bus
+ * allowing multiple device drivers to use the same buffered can for their
+ * operations.
+ *
+ * This interface does not provide APIs for CAN message hardware filtering. The
+ * hardware implementation for CAN message filter varies wildly across devices
+ * and thus a common API is infeasible. So we rely on the concrete classes, the
+ * implementations of this interface to provide APIs for setting the CAN filter
+ * for the specific hardware. Hardware filtering is a best effort with the
+ * resources available. It is often not possible to filter every possible ID in
+ * hardware that your application is interested in. Thus, must expect that the
+ * CAN message receive buffer.
+ *
+ * All implementations MUST allow the user to supply their own message buffer of
+ * arbitrary size up to the limits of what hardware can support. This allows a
+ * developer the ability to tailored the buffer size to the needs of the
+ * application.
+ *
+ * All CAN messages that pass through the hardware filter will be added to the,
+ * message circular buffer.
+ */
+class buffered_can
+{
+public:
+  /**
+   * @brief Configure this can bus port to match the settings supplied
+   *
+   * @param p_settings - settings to apply to can driver
+   * @throws hal::operation_not_supported - if the settings could not be
+   * achieved.
+   */
+  void configure(can_settings const& p_settings)
+  {
+    driver_configure(p_settings);
+  }
+
+  /**
+   * @brief Transition the CAN device from "bus-off" to "bus-on"
+  @verbatim embed:rst
+  ```{warning}
+  Calling this function when the device is already in "bus-on" will
+  have no effect. This function is not necessary to call after creating the
+  CAN driver as the driver should already be "bus-on" on creation.
+  ```
+  @endverbatim
+   *
+   * Can devices have two counters to determine system health. These two
+   * counters are the "transmit error counter" and the "receive error counter".
+   * Transmission errors can occur when the device attempts to communicate on
+   * the bus and either does not get an acknowledge or sees an unexpected or
+   * erroneous signal on the bus during its own transmission. When transmission
+   * errors reach 255 counts, the device will go into the "bus-off" state.
+   *
+   * In the "bus-off" state, the CAN peripheral can no longer communicate on the
+   * bus. Any calls to `send()` will throw the error
+   * `hal::operation_not_permitted`. If this occurs, this function must be
+   * called to re-enable bus communication.
+   *
+   */
+  void bus_on()
+  {
+    driver_bus_on();
+  }
+
+  /**
+   * @brief Send a can message
+   *
+   * @param p_message - the message to be sent
+   * @throws hal::operation_not_permitted - if the can device has entered the
+   * "bus-off" state. This can happen if a critical fault in the bus has
+   * occurred. A call to `bus_on()` will need to be issued to attempt to talk on
+   * the bus again. See `bus_on()` for more details.
+   */
+  void send(can_message const& p_message)
+  {
+    driver_send(p_message);
+  }
+
+  /**
+   * @brief Returns this CAN driver's message receive buffer
+   *
+   * Use this along with the receive_cursor() in order to determine if new data
+   * has been read into the receive buffer. See the docs for `receive_cursor()`
+   * for more details.
+   *
+   * @return std::span<message const> - constant span to the message receive
+   * buffer used by this driver. Assume the lifetime of the buffer is the same
+   * as the class's lifetime. When the memory of the owning object is
+   * invalidated, so is this span.
+   */
+  std::span<can_message const> receive_buffer()
+  {
+    return driver_receive_buffer();
+  }
+
+  /**
+   * @brief Returns the write position (head) of the circular receive buffer
+   *
+   * Receive head represents the position where the next byte of data will be
+   * written in the receive buffer. This position advances as new data arrives.
+   * To determine how much new data has arrived, store the previous head
+   * position and compare it with the current head position, accounting for
+   * buffer wraparound.
+   *
+   * Example:
+   *
+   *   auto old_head = port.receive_cursor();
+   *   // ... wait for new data ...
+   *   auto new_head = port.receive_cursor();
+   *   // Account for circular wraparound when calculating messages received
+   *   auto buffer_size = port.receive_buffer().size();
+   *   auto messages_received =
+   *          (new_head + buffer_size - old_head) % buffer_size;
+   *
+   * The data between your last saved position and the current head position
+   * represents the newly received messages. When reading the data, remember
+   * that it may wrap around from the end of the buffer back to the beginning.
+   *
+   * @return std::size_t - Current write position in the circular receive buffer
+   */
+  std::size_t receive_cursor()
+  {
+    return driver_receive_cursor();
+  }
+
+  virtual ~buffered_can() = default;
+
+private:
+  virtual void driver_configure(can_settings const& p_settings) = 0;
+  virtual void driver_bus_on() = 0;
+  virtual void driver_send(can_message const& p_message) = 0;
+  virtual std::span<can_message const> driver_receive_buffer() = 0;
+  virtual std::size_t driver_receive_cursor() = 0;
+};
+}  // namespace hal

--- a/include/libhal/buffered_can.hpp
+++ b/include/libhal/buffered_can.hpp
@@ -58,6 +58,12 @@ struct can_message
    * If true, then length and payload are ignored.
    */
   bool is_remote_request = false;
+
+  /**
+   * @brief Enables default comparison
+   *
+   */
+  bool operator<=>(can_message const&) const = default;
 };
 
 /**
@@ -104,6 +110,12 @@ struct can_settings
    *
    */
   hertz baud_rate = 100.0_kHz;
+
+  /**
+   * @brief Enables default comparison
+   *
+   */
+  bool operator<=>(can_settings const&) const = default;
 };
 
 /**
@@ -228,7 +240,7 @@ public:
    * represents the newly received messages. When reading the data, remember
    * that it may wrap around from the end of the buffer back to the beginning.
    *
-   * @return std::size_t - Current write position in the circular receive buffer
+   * @return std::size_t - position of the write cursor for the circular buffer
    */
   std::size_t receive_cursor()
   {

--- a/include/libhal/buffered_can.hpp
+++ b/include/libhal/buffered_can.hpp
@@ -210,7 +210,8 @@ public:
    * @return std::span<message const> - constant span to the message receive
    * buffer used by this driver. Assume the lifetime of the buffer is the same
    * as the class's lifetime. When the memory of the owning object is
-   * invalidated, so is this span.
+   * invalidated, so is this span. Calling `size()` on the span will always
+   * return a value of at least 1.
    */
   std::span<can_message const> receive_buffer()
   {
@@ -218,13 +219,22 @@ public:
   }
 
   /**
-   * @brief Returns the write position (head) of the circular receive buffer
+   * @brief Returns the current write position of the circular receive buffer
    *
-   * Receive head represents the position where the next byte of data will be
-   * written in the receive buffer. This position advances as new data arrives.
-   * To determine how much new data has arrived, store the previous head
-   * position and compare it with the current head position, accounting for
-   * buffer wraparound.
+   * Receive head represents the position where the next message will be written
+   * in the receive buffer. This position advances as new messages arrives. To
+   * determine how much new data has arrived, store the previous head position
+   * and compare it with the current head position, accounting for buffer
+   * wraparound.
+   *
+   * The cursor value will ALWAYS follow this equation:
+   *
+   *          0 <= cursor && cursor < receive_buffer().size()
+   *
+   * Thus this expression is always a valid memory access but may not return
+   * useful information:
+   *
+   *         can.receive_buffer()[ can.cursor() ];
    *
    * Example:
    *
@@ -240,7 +250,7 @@ public:
    * represents the newly received messages. When reading the data, remember
    * that it may wrap around from the end of the buffer back to the beginning.
    *
-   * @return std::size_t - position of the write cursor for the circular buffer
+   * @return std::size_t - position of the write cursor for the circular buffer.
    */
   std::size_t receive_cursor()
   {

--- a/include/libhal/i2c.hpp
+++ b/include/libhal/i2c.hpp
@@ -49,6 +49,12 @@ public:
      *
      */
     hertz clock_rate = 100.0_kHz;
+
+    /**
+     * @brief Enables default comparison
+     *
+     */
+    bool operator<=>(settings const&) const = default;
   };
 
   /**

--- a/include/libhal/i2c.hpp
+++ b/include/libhal/i2c.hpp
@@ -29,6 +29,11 @@ namespace hal {
  * because it only requires two connections SDA (data signal) and SCL (clock
  * signal). This is possible because the protocol for I2C is addressable.
  *
+ * Some devices can utilize clock stretching as a means to pause the i2c
+ * controller until the device is ready to respond. To ensure operations with
+ * i2c are deterministic and reliably it is advised to NEVER use a clock
+ * stretching device in your application.
+ *
  */
 class i2c
 {
@@ -93,6 +98,44 @@ public:
    * nullptr with length zero in order to skip writing.
    * @param p_data_in buffer to store read data from the addressed device. Set
    * to nullptr with length 0 in order to skip reading.
+   * @throws hal::no_such_device - indicates that no devices on
+   * the bus acknowledge the address in this transaction, which could mean that
+   * the device is not connected to the bus, is not powered, not available to
+   * respond, broken or many other possible outcomes.
+   * @throws hal::io_error - indicates that the i2c lines were put into an
+   * invalid state during the transaction due to interference, misconfiguration,
+   * hardware fault, malfunctioning i2c peripheral or possibly something else.
+   * This tends to present a hardware issue and is usually not recoverable.
+   */
+  void transaction(hal::byte p_address,
+                   std::span<hal::byte const> p_data_out,
+                   std::span<hal::byte> p_data_in)
+  {
+    driver_transaction(p_address, p_data_out, p_data_in);
+  }
+
+  /**
+   * @deprecated Prefer to use the i2c API that does not use timeouts. Timeout
+   * functions get in the way of an efficient usage of DMA, is a viral
+   * performance hit, and is only for the rare situation where a device on the
+   * bus may perform clock stretching for which there are few devices that
+   * support this. The deprecated attribute is not used yet, as the transition
+   * is still ongoing.
+   *
+   * @brief perform an i2c transaction with another device on the bus. The type
+   * of transaction depends on values of input parameters. This function will
+   * block until the entire transfer is finished.
+   *
+   *
+   * @param p_address 7-bit address of the device you want to communicate with.
+   * To perform a transaction with a 10-bit address, this parameter must be the
+   * address upper byte of the 10-bit address OR'd with 0b1111'0000 (the 10-bit
+   * address indicator). The lower byte of the address must be contained in the
+   * first byte of the p_data_out span.
+   * @param p_data_out data to be written to the addressed device. Set to
+   * nullptr with length zero in order to skip writing.
+   * @param p_data_in buffer to store read data from the addressed device. Set
+   * to nullptr with length 0 in order to skip reading.
    * @param p_timeout callable which notifies the i2c driver that it has run out
    * of time to perform the transaction and must stop and return control to the
    * caller.
@@ -102,9 +145,6 @@ public:
    * the bus acknowledge the address in this transaction, which could mean that
    * the device is not connected to the bus, is not powered, not available to
    * respond, broken or many other possible outcomes.
-   * @throws hal::resource_unavailable_try_again - if there is another
-   * controller on the bus and it won control of the bus, this transaction is
-   * canceled and this exception is thrown.
    * @throws hal::io_error - indicates that the i2c lines were put into an
    * invalid state during the transaction due to interference, misconfiguration,
    * hardware fault, malfunctioning i2c peripheral or possibly something else.
@@ -122,10 +162,25 @@ public:
 
 private:
   virtual void driver_configure(settings const& p_settings) = 0;
+
+  /// Implementors of this virtual API should simply call the concrete class's
+  /// implementation of driver_transaction() without the p_timeout parameter and
+  /// drop the p_timeout parameter.
   virtual void driver_transaction(
     hal::byte p_address,
     std::span<hal::byte const> p_data_out,
     std::span<hal::byte> p_data_in,
     hal::function_ref<hal::timeout_function> p_timeout) = 0;
+
+  /// The default implementation of this calls the original driver_transaction
+  /// with a never timeout parameter. This is to make this API call backwards
+  /// compatible.
+  virtual void driver_transaction(hal::byte p_address,
+                                  std::span<hal::byte const> p_data_out,
+                                  std::span<hal::byte> p_data_in)
+  {
+    // NOLINTNEXTLINE
+    transaction(p_address, p_data_out, p_data_in, hal::never_timeout());
+  }
 };
 }  // namespace hal

--- a/include/libhal/no_copy_serial.hpp
+++ b/include/libhal/no_copy_serial.hpp
@@ -1,0 +1,149 @@
+// Copyright 2024 Khalil Estell
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstddef>
+#include <span>
+
+#include "serial.hpp"
+#include "units.hpp"
+
+namespace hal {
+/**
+ * @brief Hardware abstract interface for the serial communication protocol
+ *
+ * Use this interface for hardware that implements a serial protocol like UART,
+ * RS232, RS485 and others that use a similar communication protocol but may use
+ * different voltage schemes.
+ *
+ * This interface only works 8-bit serial data frames.
+ *
+ * Due to the asynchronous and unformatted nature of serial communication
+ * protocols, all implementations of serial devices must be buffered. Buffered,
+ * in this case, is defined as automatic storage of received bytes without
+ * direct application intervention.
+ *
+ * All implementations MUST allow the user to supply their own buffer of
+ * arbitrary size up to the limits of what hardware can support. This allows a
+ * developer the ability to tailored the buffer size to the needs of the
+ * application.
+ *
+ * Examples of buffering schemes are:
+ *
+ * - Using DMA to copy data from a serial peripheral to a region of memory
+ * - Using interrupts when a serial peripheral's queue has filled to a point.
+ *   Refrain from using interrupts if the peripheral's byte queue is only of
+ *   size 1. This is bad for runtime performance and can result in missed bytes.
+ *
+ */
+class zero_copy_serial
+{
+public:
+  /**
+   * @brief Configure serial to match the settings supplied
+   *
+   * Implementing drivers must verify if the settings can be applied to hardware
+   * before modifying the hardware. This will ensure that if this operation
+   * fails, the state of the serial device has not changed.
+   *
+   * @param p_settings - settings to apply to serial driver
+   * @throws hal::operation_not_supported - if the settings could not be
+   * achieved.
+   */
+  void configure(hal::serial::settings const& p_settings)
+  {
+    driver_configure(p_settings);
+  }
+
+  /**
+   * @brief Write data to the transmitter line of the serial port
+   *
+   * @param p_data - data to be transmitted over the serial port
+   */
+  void write(std::span<hal::byte const> p_data)
+  {
+    driver_write(p_data);
+  }
+
+  /**
+   * @brief Returns this serial driver's receive buffer
+   *
+   * Use this along with the receive_head() in order to determine if new data
+   * has been read into the receive buffer. See the docs for `receive_head()`
+   * for more details.
+   *
+   * @return std::span<hal::byte const> - a const span to the receive buffer
+   * used by the serial port.
+   */
+  [[nodiscard]] std::span<hal::byte const> receive_buffer()
+  {
+    return driver_receive_buffer();
+  }
+
+  /**
+   * @brief Returns the write position (head) of the circular receive buffer
+   *
+   * Receive head represents the position where the next byte of data will be
+   * written in the receive buffer. This position advances as new data arrives.
+   * To determine how much new data has arrived, store the previous head
+   * position and compare it with the current head position, accounting for
+   * buffer wraparound.
+   *
+   * Example:
+   *
+   *   auto old_head = port.receive_head();
+   *   // ... wait for new data ...
+   *   auto new_head = port.receive_head();
+   *   // Account for circular wraparound when calculating bytes received
+   *   auto buffer_size = port.receive_buffer().size();
+   *   auto bytes_received = (new_head + buffer_size - old_head) % buffer_size;
+   *
+   * Use this along with receive_buffer() to access newly received data. The
+   * data between your last saved position and the current head position
+   * represents the newly received bytes. When reading the data, remember that
+   * it may wrap around from the end of the buffer back to the beginning.
+   *
+   * @return std::size_t - Current write position in the circular receive buffer
+   */
+  [[nodiscard]] std::size_t receive_cursor()
+  {
+    return driver_cursor();
+  }
+
+  /**
+   * @brief Flush working buffer
+   *
+   * The behavior of flushing the internal working buffer is this:
+   *
+   * 1. Stop data reception.
+   * 2. Clear any received data stored in hardware FIFOs.
+   * 3. Write zeros to circular buffer.
+   * 4. Enable data reception.
+   */
+  void flush()
+  {
+    driver_flush();
+  }
+
+  virtual ~zero_copy_serial() = default;
+
+private:
+  virtual void driver_configure(hal::serial::settings const& p_settings) = 0;
+  virtual void driver_write(std::span<hal::byte const> p_data) = 0;
+  virtual std::span<hal::byte const> driver_receive_buffer() = 0;
+  virtual std::size_t driver_cursor() = 0;
+  virtual void driver_flush() = 0;
+};
+}  // namespace hal

--- a/include/libhal/serial.hpp
+++ b/include/libhal/serial.hpp
@@ -85,6 +85,12 @@ public:
 
     /// Parity bit type for each frame
     parity parity = parity::none;
+
+    /**
+     * @brief Enables default comparison
+     *
+     */
+    bool operator<=>(settings const&) const = default;
   };
 
   /// Return type for serial read operations

--- a/include/libhal/serial.hpp
+++ b/include/libhal/serial.hpp
@@ -22,6 +22,7 @@
 
 namespace hal {
 /**
+ * @deprecated Use `zero_copy_serial` instead for better performance
  * @brief Hardware abstract interface for the serial communication protocol
  *
  * Use this interface for hardware that implements a serial protocol like UART,
@@ -43,7 +44,9 @@ namespace hal {
  * Examples of buffering schemes are:
  *
  * - Using DMA to copy data from a serial peripheral to a region of memory
- * - Using interrupts when a serial peripheral's queue has filled to a point
+ * - Using interrupts when a serial peripheral's queue has filled to a point.
+ *   Refrain from using interrupts if the peripheral's byte queue is only of
+ *   size 1. This is bad for runtime performance and can result in missed bytes.
  *
  */
 class serial

--- a/include/libhal/zero_copy_serial.hpp
+++ b/include/libhal/zero_copy_serial.hpp
@@ -85,7 +85,8 @@ public:
    * for more details.
    *
    * @return std::span<hal::byte const> - a const span to the receive buffer
-   * used by the serial port.
+   * used by the serial port. Calling `size()` on the span will always
+   * return a value of at least 1.
    */
   [[nodiscard]] std::span<hal::byte const> receive_buffer()
   {
@@ -93,13 +94,24 @@ public:
   }
 
   /**
-   * @brief Returns the write position (head) of the circular receive buffer
+   * @brief Returns the current write position of the circular receive buffer
    *
    * Receive head represents the position where the next byte of data will be
-   * written in the receive buffer. This position advances as new data arrives.
-   * To determine how much new data has arrived, store the previous head
-   * position and compare it with the current head position, accounting for
+   * written in to the receive buffer. This position advances as new data
+   * arrives. To determine how much new data has arrived, store the previous
+   * head position and compare it with the current head position, accounting for
    * buffer wraparound.
+   *
+   * The cursor value will ALWAYS follow this equation:
+   *
+   *          0 <= cursor && cursor < receive_buffer().size()
+   *
+   * Thus making the following expression valid memory access:
+   *
+   *         serial.receive_buffer()[ serial.cursor() ];
+   *
+   * Just note that just because it is valid does not mean that there is useful
+   * information at this position.
    *
    * Example:
    *

--- a/include/libhal/zero_copy_serial.hpp
+++ b/include/libhal/zero_copy_serial.hpp
@@ -115,26 +115,11 @@ public:
    * represents the newly received bytes. When reading the data, remember that
    * it may wrap around from the end of the buffer back to the beginning.
    *
-   * @return std::size_t - Current write position in the circular receive buffer
+   * @return std::size_t - position of the write cursor for the circular buffer
    */
   [[nodiscard]] std::size_t receive_cursor()
   {
     return driver_cursor();
-  }
-
-  /**
-   * @brief Flush working buffer
-   *
-   * The behavior of flushing the internal working buffer is this:
-   *
-   * 1. Stop data reception.
-   * 2. Clear any received data stored in hardware FIFOs.
-   * 3. Write zeros to circular buffer.
-   * 4. Enable data reception.
-   */
-  void flush()
-  {
-    driver_flush();
   }
 
   virtual ~zero_copy_serial() = default;
@@ -144,6 +129,5 @@ private:
   virtual void driver_write(std::span<hal::byte const> p_data) = 0;
   virtual std::span<hal::byte const> driver_receive_buffer() = 0;
   virtual std::size_t driver_cursor() = 0;
-  virtual void driver_flush() = 0;
 };
 }  // namespace hal

--- a/tests/adc.test.cpp
+++ b/tests/adc.test.cpp
@@ -36,10 +36,9 @@ private:
 };
 }  // namespace
 
-void adc_test()
-{
+boost::ut::suite<"hal::adc"> adc_test = []() {
   using namespace boost::ut;
-  "adc interface test"_test = []() {
+  "::read()"_test = []() {
     // Setup
     test_adc test;
 
@@ -49,5 +48,5 @@ void adc_test()
     // Verify
     expect(that % expected_value == sample);
   };
-}
+};
 }  // namespace hal

--- a/tests/angular_velocity_sensor.test.cpp
+++ b/tests/angular_velocity_sensor.test.cpp
@@ -31,16 +31,15 @@ private:
 };
 }  // namespace
 
-void angular_velocity_sensor_test()
-{
-  using namespace boost::ut;
-  "angular velocity sensor interface test"_test = []() {
-    test_angular_velocity_sensor test;
+boost::ut::suite<"angular_velocity_sensor_test"> angular_velocity_sensor_test =
+  []() {
+    using namespace boost::ut;
+    "angular velocity sensor interface test"_test = []() {
+      test_angular_velocity_sensor test;
 
-    auto result = test.read();
+      auto result = test.read();
 
-    expect(hal::rpm(5.0) == result);
+      expect(hal::rpm(5.0) == result);
+    };
   };
-}
-
 }  // namespace hal

--- a/tests/current_sensor.test.cpp
+++ b/tests/current_sensor.test.cpp
@@ -33,16 +33,16 @@ private:
 };
 }  // namespace
 
-void current_sensor_test()
-{
-  using namespace boost::ut;
-  "current sensor interface test"_test = []() {
-    test_current_sensor test;
+boost::ut::suite current_sensor_test = []() {
+  {
+    using namespace boost::ut;
+    "current sensor interface test"_test = []() {
+      test_current_sensor test;
 
-    auto sample = test.read();
+      auto sample = test.read();
 
-    expect(expected_value == sample);
-  };
-}
-
+      expect(expected_value == sample);
+    };
+  }
+};
 }  // namespace hal

--- a/tests/dac.test.cpp
+++ b/tests/dac.test.cpp
@@ -35,20 +35,21 @@ private:
 };
 }  // namespace
 
-void dac_test()
-{
-  using namespace boost::ut;
-
-  "dac interface test"_test = []() {
+boost::ut::suite<"dac_test"> dac_test = []() {
+  {
     using namespace boost::ut;
-    // Setup
-    test_dac test;
 
-    // Exercise
-    test.write(expected_value);
+    "dac interface test"_test = []() {
+      using namespace boost::ut;
+      // Setup
+      test_dac test;
 
-    // Verify
-    expect(that % expected_value == test.m_passed_value);
+      // Exercise
+      test.write(expected_value);
+
+      // Verify
+      expect(that % expected_value == test.m_passed_value);
+    };
   };
 };
 }  // namespace hal

--- a/tests/g_force.test.cpp
+++ b/tests/g_force.test.cpp
@@ -22,54 +22,54 @@
 
 namespace hal {
 
-void g_force_test()
-{
-  using namespace hal::literals;
-  using namespace boost::ut;
-  "g_force_type UDL test"_test = []() {
-    // Set Up
-    g_force test_g_force_value = 2.0_g;
-    float control_value = 2.0;
-    // Verify
-    expect(that % control_value == test_g_force_value);
-  };
+boost::ut::suite g_force_test = []() {
+  {
+    using namespace hal::literals;
+    using namespace boost::ut;
+    "g_force_type UDL test"_test = []() {
+      // Set Up
+      g_force test_g_force_value = 2.0_g;
+      float control_value = 2.0;
+      // Verify
+      expect(that % control_value == test_g_force_value);
+    };
 
-  "g_force_type calculation test"_test = []() {
-    // Setup
-    float earth_accelereation_rate = 9.81;  // m/s^2
-    g_force earth_g_force = 1.0_g;
+    "g_force_type calculation test"_test = []() {
+      // Setup
+      float earth_accelereation_rate = 9.81;  // m/s^2
+      g_force earth_g_force = 1.0_g;
 
-    // Test Multiplication and Division
-    g_force g_force_quotient = earth_accelereation_rate / 9.81f;
-    g_force g_force_product = 1.5_g * 2;
+      // Test Multiplication and Division
+      g_force g_force_quotient = earth_accelereation_rate / 9.81f;
+      g_force g_force_product = 1.5_g * 2;
 
-    // // Attempting to sum g_force together
-    g_force g_force_sum = 1.0_g + 1.5_g;
-    g_force g_force_difference = 1.0_g - 1.5_g;
+      // // Attempting to sum g_force together
+      g_force g_force_sum = 1.0_g + 1.5_g;
+      g_force g_force_difference = 1.0_g - 1.5_g;
 
-    // Verify
-    expect(that %
-           compare_floats({ .a = earth_g_force, .b = g_force_quotient }));
-    expect(that % compare_floats({ .a = 3.0_g, .b = g_force_product }));
-    expect(that % compare_floats({ .a = 2.5_g, .b = g_force_sum }));
-    expect(that % compare_floats({ .a = -0.5_g, .b = g_force_difference }));
-  };
+      // Verify
+      expect(that %
+             compare_floats({ .a = earth_g_force, .b = g_force_quotient }));
+      expect(that % compare_floats({ .a = 3.0_g, .b = g_force_product }));
+      expect(that % compare_floats({ .a = 2.5_g, .b = g_force_sum }));
+      expect(that % compare_floats({ .a = -0.5_g, .b = g_force_difference }));
+    };
 
-  "g_force_type boundry test"_test = []() {
-    // Set up
-    g_force g_force_max = std::numeric_limits<g_force>::max();
-    g_force g_force_min = std::numeric_limits<g_force>::min();
+    "g_force_type boundry test"_test = []() {
+      // Set up
+      g_force g_force_max = std::numeric_limits<g_force>::max();
+      g_force g_force_min = std::numeric_limits<g_force>::min();
 
-    // Control values
-    float float_max = std::numeric_limits<float>::max();
-    float float_min = std::numeric_limits<float>::min();
+      // Control values
+      float float_max = std::numeric_limits<float>::max();
+      float float_min = std::numeric_limits<float>::min();
 
-    // Verify
-    expect(that % compare_floats(
-                    { .a = float_max, .b = static_cast<float>(g_force_max) }));
-    expect(that % compare_floats(
-                    { .a = float_min, .b = static_cast<float>(g_force_min) }));
-  };
-}
-
+      // Verify
+      expect(that % compare_floats({ .a = float_max,
+                                     .b = static_cast<float>(g_force_max) }));
+      expect(that % compare_floats({ .a = float_min,
+                                     .b = static_cast<float>(g_force_min) }));
+    };
+  }
+};
 }  // namespace hal

--- a/tests/initializers.test.cpp
+++ b/tests/initializers.test.cpp
@@ -40,81 +40,82 @@ struct test_class_allocator
 };
 }  // namespace
 
-void initializers_test()
-{
-  using namespace boost::ut;
-  "create_unique_static_buffer()"_test = []() {
-    // Setup
-    auto span1 = hal::create_unique_static_buffer(buffer<128>);
-    auto span2 = hal::create_unique_static_buffer(buffer<128>);
-    auto span3 = hal::create_unique_static_buffer(buffer<256>);
-    auto span4 = hal::create_unique_static_buffer(buffer<64>);
-    auto span5 = hal::create_unique_static_buffer(buffer<72>);
+boost::ut::suite<"initializers_test"> initializers_test = []() {
+  {
+    using namespace boost::ut;
+    "create_unique_static_buffer()"_test = []() {
+      // Setup
+      auto span1 = hal::create_unique_static_buffer(buffer<128>);
+      auto span2 = hal::create_unique_static_buffer(buffer<128>);
+      auto span3 = hal::create_unique_static_buffer(buffer<256>);
+      auto span4 = hal::create_unique_static_buffer(buffer<64>);
+      auto span5 = hal::create_unique_static_buffer(buffer<72>);
 
-    test_class_allocator test1(port<2>, buffer<128>);
-    test_class_allocator test2(port<0>, buffer<512>);
-    test_class_allocator test3(port<1>, buffer<128>);
+      test_class_allocator test1(port<2>, buffer<128>);
+      test_class_allocator test2(port<0>, buffer<512>);
+      test_class_allocator test3(port<1>, buffer<128>);
 
-    // Exercise
-    // Verify
-    // Verify: Sizes of each span
-    expect(that % 128 == span1.size());
-    expect(that % 128 == span2.size());
-    expect(that % 256 == span3.size());
-    expect(that % 64 == span4.size());
-    expect(that % 72 == span5.size());
-    expect(that % 128 == test1.m_buffer.size());
-    expect(that % 512 == test2.m_buffer.size());
-    expect(that % 128 == test3.m_buffer.size());
+      // Exercise
+      // Verify
+      // Verify: Sizes of each span
+      expect(that % 128 == span1.size());
+      expect(that % 128 == span2.size());
+      expect(that % 256 == span3.size());
+      expect(that % 64 == span4.size());
+      expect(that % 72 == span5.size());
+      expect(that % 128 == test1.m_buffer.size());
+      expect(that % 512 == test2.m_buffer.size());
+      expect(that % 128 == test3.m_buffer.size());
 
-    expect(that % span1.data() == span1.data());
-    expect(that % span1.data() != span2.data());
-    expect(that % span1.data() != span3.data());
-    expect(that % span1.data() != span4.data());
-    expect(that % span1.data() != span5.data());
-    expect(that % span1.data() != test1.m_buffer.data());
-    expect(that % span1.data() != test2.m_buffer.data());
-    expect(that % span1.data() != test3.m_buffer.data());
+      expect(that % span1.data() == span1.data());
+      expect(that % span1.data() != span2.data());
+      expect(that % span1.data() != span3.data());
+      expect(that % span1.data() != span4.data());
+      expect(that % span1.data() != span5.data());
+      expect(that % span1.data() != test1.m_buffer.data());
+      expect(that % span1.data() != test2.m_buffer.data());
+      expect(that % span1.data() != test3.m_buffer.data());
 
-    expect(that % span2.data() != span1.data());
-    expect(that % span2.data() == span2.data());
-    expect(that % span2.data() != span3.data());
-    expect(that % span2.data() != span4.data());
-    expect(that % span2.data() != span5.data());
-    expect(that % span2.data() != test1.m_buffer.data());
-    expect(that % span2.data() != test2.m_buffer.data());
-    expect(that % span2.data() != test3.m_buffer.data());
+      expect(that % span2.data() != span1.data());
+      expect(that % span2.data() == span2.data());
+      expect(that % span2.data() != span3.data());
+      expect(that % span2.data() != span4.data());
+      expect(that % span2.data() != span5.data());
+      expect(that % span2.data() != test1.m_buffer.data());
+      expect(that % span2.data() != test2.m_buffer.data());
+      expect(that % span2.data() != test3.m_buffer.data());
 
-    expect(that % span3.data() != span1.data());
-    expect(that % span3.data() != span2.data());
-    expect(that % span3.data() == span3.data());
-    expect(that % span3.data() != span4.data());
-    expect(that % span3.data() != span5.data());
-    expect(that % span3.data() != test1.m_buffer.data());
-    expect(that % span3.data() != test2.m_buffer.data());
-    expect(that % span3.data() != test3.m_buffer.data());
+      expect(that % span3.data() != span1.data());
+      expect(that % span3.data() != span2.data());
+      expect(that % span3.data() == span3.data());
+      expect(that % span3.data() != span4.data());
+      expect(that % span3.data() != span5.data());
+      expect(that % span3.data() != test1.m_buffer.data());
+      expect(that % span3.data() != test2.m_buffer.data());
+      expect(that % span3.data() != test3.m_buffer.data());
 
-    expect(that % span4.data() != span1.data());
-    expect(that % span4.data() != span2.data());
-    expect(that % span4.data() != span3.data());
-    expect(that % span4.data() == span4.data());
-    expect(that % span4.data() != span5.data());
-    expect(that % span4.data() != test1.m_buffer.data());
-    expect(that % span4.data() != test2.m_buffer.data());
-    expect(that % span4.data() != test3.m_buffer.data());
+      expect(that % span4.data() != span1.data());
+      expect(that % span4.data() != span2.data());
+      expect(that % span4.data() != span3.data());
+      expect(that % span4.data() == span4.data());
+      expect(that % span4.data() != span5.data());
+      expect(that % span4.data() != test1.m_buffer.data());
+      expect(that % span4.data() != test2.m_buffer.data());
+      expect(that % span4.data() != test3.m_buffer.data());
 
-    expect(that % span5.data() != span1.data());
-    expect(that % span5.data() != span2.data());
-    expect(that % span5.data() != span3.data());
-    expect(that % span5.data() != span4.data());
-    expect(that % span5.data() == span5.data());
-    expect(that % span5.data() != test1.m_buffer.data());
-    expect(that % span5.data() != test2.m_buffer.data());
-    expect(that % span5.data() != test3.m_buffer.data());
+      expect(that % span5.data() != span1.data());
+      expect(that % span5.data() != span2.data());
+      expect(that % span5.data() != span3.data());
+      expect(that % span5.data() != span4.data());
+      expect(that % span5.data() == span5.data());
+      expect(that % span5.data() != test1.m_buffer.data());
+      expect(that % span5.data() != test2.m_buffer.data());
+      expect(that % span5.data() != test3.m_buffer.data());
 
-    expect(that % test1.m_buffer.data() != test2.m_buffer.data());
-    expect(that % test1.m_buffer.data() != test3.m_buffer.data());
-    expect(that % test2.m_buffer.data() != test3.m_buffer.data());
+      expect(that % test1.m_buffer.data() != test2.m_buffer.data());
+      expect(that % test1.m_buffer.data() != test3.m_buffer.data());
+      expect(that % test2.m_buffer.data() != test3.m_buffer.data());
+    };
   };
 };
 }  // namespace hal

--- a/tests/input_pin.test.cpp
+++ b/tests/input_pin.test.cpp
@@ -41,8 +41,7 @@ private:
 };
 }  // namespace
 
-void input_pin_test()
-{
+boost::ut::suite<"input_pin_test"> input_pin_test = []() {
   using namespace boost::ut;
   "input_pin interface test"_test = []() {
     // Setup

--- a/tests/interrupt_pin.test.cpp
+++ b/tests/interrupt_pin.test.cpp
@@ -45,8 +45,7 @@ private:
 };
 }  // namespace
 
-void interrupt_pin_test()
-{
+boost::ut::suite<"interrupt_pin_test"> interrupt_pin_test = []() {
   using namespace boost::ut;
   "interrupt_pin interface test"_test = []() {
     // Setup

--- a/tests/io_waiter.test.cpp
+++ b/tests/io_waiter.test.cpp
@@ -17,8 +17,7 @@
 #include <boost/ut.hpp>
 
 namespace hal {
-void io_waiter_test()
-{
+boost::ut::suite io_waiter_test = []() {
   using namespace boost::ut;
   "spin lock waiter test"_test = []() {
     // Setup
@@ -28,5 +27,5 @@ void io_waiter_test()
     test_subject.wait();
     test_subject.resume();
   };
-}
+};
 }  // namespace hal

--- a/tests/lengths.test.cpp
+++ b/tests/lengths.test.cpp
@@ -20,8 +20,7 @@
 
 namespace hal {
 
-void lengths_test()
-{
+boost::ut::suite<"lengths_test"> lengths_test = []() {
   using namespace hal::literals;
   using namespace boost::ut;
   constexpr float meters_in_inches = 0.0254f;
@@ -178,6 +177,5 @@ void lengths_test()
     mile_result -= 1.0_miles;
     expect(that % compare_floats({ .a = mile_result, .b = 1.0_miles }));
   };
-}
-
+};
 }  // namespace hal

--- a/tests/lock.test.cpp
+++ b/tests/lock.test.cpp
@@ -60,8 +60,7 @@ private:
 };
 }  // namespace
 
-void lock_test()
-{
+boost::ut::suite<"lock_test"> lock_test = []() {
   using namespace boost::ut;
 
   "lock"_test = []() {

--- a/tests/main.test.cpp
+++ b/tests/main.test.cpp
@@ -13,56 +13,11 @@
 // limitations under the License.
 
 namespace hal {
-extern void adc_test();
-extern void can_test();
-extern void dac_test();
-extern void error_test();
-extern void i2c_test();
-extern void input_pin_test();
-extern void interrupt_pin_test();
-extern void motor_test();
-extern void output_pin_test();
-extern void pwm_test();
-extern void serial_test();
-extern void spi_test();
-extern void steady_clock_test();
-extern void timeout_test();
-extern void timer_test();
-extern void servo_test();
-extern void g_force_test();
-extern void lengths_test();
-extern void angular_velocity_sensor_test();
-extern void current_sensor_test();
-extern void initializers_test();
-extern void stream_dac_test();
-extern void io_waiter_test();
-extern void lock_test();
+// Extern position dependant test go here. Refrain from using this whenever
+// possible.
 }  // namespace hal
 
 int main()
 {
-  hal::adc_test();
-  hal::can_test();
-  hal::dac_test();
-  hal::error_test();
-  hal::i2c_test();
-  hal::input_pin_test();
-  hal::initializers_test();
-  hal::interrupt_pin_test();
-  hal::motor_test();
-  hal::output_pin_test();
-  hal::pwm_test();
-  hal::serial_test();
-  hal::spi_test();
-  hal::steady_clock_test();
-  hal::servo_test();
-  hal::timeout_test();
-  hal::timer_test();
-  hal::g_force_test();
-  hal::lengths_test();
-  hal::angular_velocity_sensor_test();
-  hal::current_sensor_test();
-  hal::stream_dac_test();
-  hal::io_waiter_test();
-  hal::lock_test();
+  // Position dependent test go below:
 }

--- a/tests/motor.test.cpp
+++ b/tests/motor.test.cpp
@@ -36,8 +36,7 @@ private:
 };
 }  // namespace
 
-void motor_test()
-{
+boost::ut::suite<"motor_test"> motor_test = []() {
   using namespace boost::ut;
   "motor interface test"_test = []() {
     // Setup

--- a/tests/output_pin.test.cpp
+++ b/tests/output_pin.test.cpp
@@ -48,10 +48,9 @@ private:
 };
 }  // namespace
 
-void output_pin_test()
-{
+boost::ut::suite<"output_pin_test"> output_pin_test = []() {
   using namespace boost::ut;
-  "output_pin interface test"_test = []() {
+  "test"_test = []() {
     // Setup
     test_output_pin test;
 

--- a/tests/pwm.test.cpp
+++ b/tests/pwm.test.cpp
@@ -42,8 +42,7 @@ private:
 };
 }  // namespace
 
-void pwm_test()
-{
+boost::ut::suite<"pwm_test"> pwm_test = []() {
   using namespace boost::ut;
   "pwm interface test"_test = []() {
     // Setup

--- a/tests/serial.test.cpp
+++ b/tests/serial.test.cpp
@@ -60,29 +60,26 @@ private:
 };
 }  // namespace
 
-void serial_test()
-{
+boost::ut::suite<"serial_test"> serial_test = []() {
   using namespace boost::ut;
-  "serial interface test"_test = []() {
-    // Setup
-    test_serial test;
-    std::array<hal::byte, 4> const expected_payload{ 'a', 'b' };
-    std::array<hal::byte, 4> expected_buffer{ '1', '2' };
+  // Setup
+  test_serial test;
+  std::array<hal::byte, 4> const expected_payload{ 'a', 'b' };
+  std::array<hal::byte, 4> expected_buffer{ '1', '2' };
 
-    // Exercise
-    test.configure(expected_settings);
-    auto write_info = test.write(expected_payload);
-    auto read_info = test.read(expected_buffer);
-    test.flush();
+  // Exercise
+  test.configure(expected_settings);
+  auto write_info = test.write(expected_payload);
+  auto read_info = test.read(expected_buffer);
+  test.flush();
 
-    // Verify
-    auto delta = expected_settings.baud_rate - test.m_settings.baud_rate;
-    expect(that % 0.001f > std::abs(delta));
-    expect(expected_settings.stop == test.m_settings.stop);
-    expect(expected_settings.parity == test.m_settings.parity);
-    expect(that % expected_payload.data() == write_info.data.data());
-    expect(that % expected_buffer.data() == read_info.data.data());
-    expect(true == test.m_flush_called);
-  };
+  // Verify
+  auto delta = expected_settings.baud_rate - test.m_settings.baud_rate;
+  expect(that % 0.001f > std::abs(delta));
+  expect(expected_settings.stop == test.m_settings.stop);
+  expect(expected_settings.parity == test.m_settings.parity);
+  expect(that % expected_payload.data() == write_info.data.data());
+  expect(that % expected_buffer.data() == read_info.data.data());
+  expect(true == test.m_flush_called);
 };
 }  // namespace hal

--- a/tests/servo.test.cpp
+++ b/tests/servo.test.cpp
@@ -36,18 +36,15 @@ private:
 };
 }  // namespace
 
-void servo_test()
-{
+boost::ut::suite<"servo_test"> servo_test = []() {
   using namespace boost::ut;
-  "servo interface test"_test = []() {
-    // Setup
-    test_servo test;
+  // Setup
+  test_servo test;
 
-    // Exercise
-    test.position(expected_value);
+  // Exercise
+  test.position(expected_value);
 
-    // Verify
-    expect(that % expected_value == test.m_position);
-  };
+  // Verify
+  expect(that % expected_value == test.m_position);
 };
 }  // namespace hal

--- a/tests/spi.test.cpp
+++ b/tests/spi.test.cpp
@@ -57,10 +57,9 @@ private:
 };
 }  // namespace
 
-void spi_test()
-{
+boost::ut::suite<"spi_test"> spi_test = []() {
   using namespace boost::ut;
-  "spi interface test"_test = []() {
+  "test"_test = []() {
     // Setup
     test_spi test;
     std::array<hal::byte, 4> const expected_out{ 'a', 'b' };
@@ -85,7 +84,8 @@ void spi_test()
     expect(expected_settings.clock_polarity == test.m_settings.clock_polarity);
     expect(expected_settings.clock_phase == test.m_settings.clock_phase);
   };
-  "spi interface test: settings2"_test = []() {
+
+  "hal::spi::settings2"_test = []() {
     // Setup
     test_spi test;
     std::array<hal::byte, 4> const expected_out{ 'a', 'b' };

--- a/tests/steady_clock.test.cpp
+++ b/tests/steady_clock.test.cpp
@@ -41,20 +41,17 @@ private:
 };
 }  // namespace
 
-void steady_clock_test()
-{
+boost::ut::suite<"steady_clock_test"> steady_clock_test = []() {
   using namespace boost::ut;
-  "steady_clock interface test"_test = []() {
-    // Setup
-    test_steady_clock test;
+  // Setup
+  test_steady_clock test;
 
-    // Exercise
-    auto frequency = test.frequency();
-    auto uptime = test.uptime();
+  // Exercise
+  auto frequency = test.frequency();
+  auto uptime = test.uptime();
 
-    // Verify
-    expect(that % test.m_frequency == frequency);
-    expect(that % test.m_uptime == uptime);
-  };
+  // Verify
+  expect(that % test.m_frequency == frequency);
+  expect(that % test.m_uptime == uptime);
 };
 }  // namespace hal

--- a/tests/stream_dac.test.cpp
+++ b/tests/stream_dac.test.cpp
@@ -35,22 +35,19 @@ private:
 };
 }  // namespace
 
-void stream_dac_test()
-{
+boost::ut::suite<"stream_dac_test"> stream_dac_test = []() {
   using namespace boost::ut;
-  "stream_dac interface test"_test = []() {
-    // Setup
-    test_stream_dac test;
-    std::array<std::uint8_t, 7> const expected_out{ 0, 1, 2, 3, 4, 5 };
-    constexpr hal::hertz expected_sample_rate = 16.0_kHz;
+  // Setup
+  test_stream_dac test;
+  std::array<std::uint8_t, 7> const expected_out{ 0, 1, 2, 3, 4, 5 };
+  constexpr hal::hertz expected_sample_rate = 16.0_kHz;
 
-    // Exercise
-    test.write({ .sample_rate = expected_sample_rate, .data = expected_out });
+  // Exercise
+  test.write({ .sample_rate = expected_sample_rate, .data = expected_out });
 
-    // Verify
-    expect(that % expected_sample_rate == test.actual_samples.sample_rate);
-    expect(that % expected_out.data() == test.actual_samples.data.data());
-    expect(that % expected_out.size() == test.actual_samples.data.size());
-  };
+  // Verify
+  expect(that % expected_sample_rate == test.actual_samples.sample_rate);
+  expect(that % expected_out.data() == test.actual_samples.data.data());
+  expect(that % expected_out.size() == test.actual_samples.data.size());
 };
 }  // namespace hal

--- a/tests/timeout.test.cpp
+++ b/tests/timeout.test.cpp
@@ -19,9 +19,9 @@
 #include <boost/ut.hpp>
 
 namespace hal {
-void timeout_test()
-{
-  using namespace boost::ut;
+boost::ut::suite timeout_test = []() {
+  {
+    using namespace boost::ut;
 #if 0
   "hal::delay(timeout)"_test = []() {
     // Setup
@@ -61,5 +61,6 @@ void timeout_test()
     expect(!bool{ result });
   };
 #endif
+  };
 };
 }  // namespace hal

--- a/tests/timer.test.cpp
+++ b/tests/timer.test.cpp
@@ -51,34 +51,35 @@ private:
 };
 }  // namespace
 
-void timer_test()
-{
-  using namespace boost::ut;
-  "timer interface test"_test = []() {
-    // Setup
-    test_timer test;
-    bool callback_stored_successfully = false;
-    hal::callback<void(void)> const expected_callback =
-      [&callback_stored_successfully]() {
-        callback_stored_successfully = true;
-      };
-    hal::time_duration const expected_delay = {};
+boost::ut::suite timer_test = []() {
+  {
+    using namespace boost::ut;
+    "timer interface test"_test = []() {
+      // Setup
+      test_timer test;
+      bool callback_stored_successfully = false;
+      hal::callback<void(void)> const expected_callback =
+        [&callback_stored_successfully]() {
+          callback_stored_successfully = true;
+        };
+      hal::time_duration const expected_delay = {};
 
-    // Exercise + Verify
-    auto is_running = test.is_running();
-    expect(that % false == is_running);
+      // Exercise + Verify
+      auto is_running = test.is_running();
+      expect(that % false == is_running);
 
-    test.schedule(expected_callback, expected_delay);
-    is_running = test.is_running();
-    expect(that % true == is_running);
-    expect(expected_delay == test.m_delay);
+      test.schedule(expected_callback, expected_delay);
+      is_running = test.is_running();
+      expect(that % true == is_running);
+      expect(expected_delay == test.m_delay);
 
-    test.m_callback();
-    expect(that % true == callback_stored_successfully);
+      test.m_callback();
+      expect(that % true == callback_stored_successfully);
 
-    test.cancel();
-    is_running = test.is_running();
-    expect(that % false == is_running);
+      test.cancel();
+      is_running = test.is_running();
+      expect(that % false == is_running);
+    };
   };
 };
 }  // namespace hal

--- a/tests/zero_copy_serial.test.cpp
+++ b/tests/zero_copy_serial.test.cpp
@@ -1,0 +1,133 @@
+// Copyright 2024 Khalil Estell
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <libhal/zero_copy_serial.hpp>
+
+#include <libhal/error.hpp>
+
+#include <boost/ut.hpp>
+#include <stdexcept>
+
+namespace hal {
+namespace {
+constexpr hal::serial::settings expected_settings{
+  .baud_rate = 115200.0f,
+  .stop = hal::serial::settings::stop_bits::two,
+  .parity = hal::serial::settings::parity::none
+};
+
+class test_serial : public hal::zero_copy_serial
+{
+public:
+  using settings = hal::serial::settings;
+  settings m_settings{};
+  std::span<hal::byte const> m_data_write{};
+  std::array<hal::byte, 4> m_working_buffer{};
+  std::size_t m_cursor{};
+  ~test_serial() override = default;
+
+  void append_data_to_receive_buffer(std::span<hal::byte const> p_data)
+  {
+    if (p_data.size() > m_working_buffer.size()) {
+      throw std::runtime_error("p_data is too big for this test API! Must be "
+                               "smaller than m_working_buffer");
+    }
+    std::copy(p_data.begin(), p_data.end(), m_working_buffer.begin());
+    m_cursor = p_data.size();
+  }
+
+private:
+  void driver_configure(settings const& p_settings) override
+  {
+    m_settings = p_settings;
+  }
+
+  void driver_write(std::span<hal::byte const> p_data) override
+  {
+    m_data_write = p_data;
+  }
+
+  std::span<hal::byte const> driver_receive_buffer() override
+  {
+    return m_working_buffer;
+  }
+
+  std::size_t driver_cursor() override
+  {
+    return m_cursor;
+  }
+};
+}  // namespace
+
+boost::ut::suite<"zero_copy_serial_test"> zero_copy_serial_test = []() {
+  using namespace boost::ut;
+
+  "::configure()"_test = []() {
+    // Setup
+    test_serial test;
+
+    // Ensure
+    expect(expected_settings != test.m_settings);
+
+    // Exercise
+    test.configure(expected_settings);
+
+    // Verify
+    expect(expected_settings == test.m_settings);
+  };
+
+  "::write"_test = []() {
+    // Setup
+    constexpr auto expected_payload =
+      std::to_array<hal::byte const>({ 'a', 'b' });
+    test_serial test;
+
+    // Ensure
+    expect(expected_payload.data() != test.m_data_write.data());
+    expect(expected_payload.size() != test.m_data_write.size());
+
+    // Exercise
+    test.write(expected_payload);
+
+    // Verify
+    expect(expected_payload.data() == test.m_data_write.data());
+    expect(expected_payload.size() == test.m_data_write.size());
+  };
+
+  "::receive_buffer() & ::receive_cursor()"_test = []() {
+    // Setup
+    constexpr auto expected_buffer = std::to_array<hal::byte>({ '1', '2' });
+    test_serial test;
+
+    // Exercise
+    auto const receive_buffer = test.receive_buffer();
+    auto const cursor1 = test.receive_cursor();
+
+    test.append_data_to_receive_buffer(expected_buffer);
+
+    auto const cursor2 = test.receive_cursor();
+    auto const cursor_distance = cursor2 - cursor1;
+
+    bool const the_are_buffers_equal =
+      std::equal(receive_buffer.begin() + cursor1,
+                 receive_buffer.begin() + cursor2,
+                 expected_buffer.begin());
+
+    // Verify
+    expect(that % expected_buffer.size() == cursor_distance);
+    expect(that % the_are_buffers_equal)
+      << "Expected buffer and cursors + buffers are not equal!";
+  };
+};
+}  // namespace hal


### PR DESCRIPTION
- i2c now has an new API transactions that do not require a timeout. The timeout parameter was used for clock stretching but clock stretching devices are so rare and problematic that its not justifiable to waste performance passing around a timeout when we should be telling users to not use clock stretching devices.
- zero_copy_serial is a version of serial that provides intrusive access to memory within the serial's working buffer along with a circular buffer index allowing access to ordered serial information without the need for
- buffered_can provides the same sort of access to can messages as zero_copy_serial. Rather than using an interrupt's callback, messages are provided by a span and a write cursor. This will eliminate the need for canrouter which has been a blight on the can design for a while.

When a breaking change to libhal 5.0.0 happens, these will replace `hal::i2c`, `hal::serial`, and `hal::can`.

Resolves https://github.com/libhal/libhal/issues/71
Resolves https://github.com/libhal/libhal/issues/70
Resolves https://github.com/libhal/libhal/issues/80