### PR TITLE
:sparkles: Add libhal 5.0.0 versions of APIs

### DIFF
--- a/include/libhal/i2c.hpp
+++ b/include/libhal/i2c.hpp
@@ -189,4 +189,102 @@ private:
     transaction(p_address, p_data_out, p_data_in, hal::never_timeout());
   }
 };
+
+namespace v5 {
+/**
+ * @brief Inter-integrated Circuit (I2C) hardware abstract interface.
+ *
+ * Also known as Two Wire Interface (TWI) communication protocol. This is a very
+ * commonly used protocol for communication with sensors and peripheral devices
+ * because it only requires two connections SDA (data signal) and SCL (clock
+ * signal). This is possible because the protocol for I2C is addressable.
+ *
+ * Some devices can utilize clock stretching as a means to pause the i2c
+ * controller until the device is ready to respond. To ensure operations with
+ * i2c are deterministic and reliably it is advised to NEVER use a clock
+ * stretching device in your application.
+ *
+ */
+class i2c
+{
+public:
+  /**
+   * @brief Get the clock rate of the i2c bus
+   *
+   * This is used by device drivers sharing this resource to determine if the
+   * clock rate is above what the device can support. If that is the case, the
+   * device should throw the exception hal::operation_not_supported to signal
+   * that the i2c is not supported for this device.
+   *
+   * NOTE: if the i2c clock rate is too high for a device on the bus it is
+   * likely that the i2c may experience and throw hal::io_errors on any
+   * transaction due to devices misinterpreting the bus signals.
+   *
+   * @returns u32 - returns the i2c device's clock rate
+   */
+  u32 clock_rate()
+  {
+    return driver_clock_rate();
+  }
+
+  /**
+   * @brief Perform an i2c transaction with another device on the bus. The type
+   * of transaction depends on values of input parameters. This function will
+   * block until the entire transfer is finished.
+   *
+   * Performing Write, Read and Write-Then-Read transactions depends on which
+   * span for data_out and data_in are set to null.
+   *
+   * - For write transactions, pass p_data_in as an empty span
+   * `std::span<hal::byte>{}` and pass a buffer to p_data_out.
+   *
+   * - For read transactions, pass p_data_out as an empty span
+   * `std::span<hal::byte const>{}` and pass a buffer to p_data_in.
+   *
+   * - For write-then-read transactions, pass a buffer for both p_data_in
+   *   p_data_out.
+   *
+   * - If both p_data_in and p_data_out are empty, simply do nothing and return
+   *   success.
+   *
+   * In the event of arbitration loss, this function will wait for the bus to
+   * become free and try again. Arbitration loss means that during the address
+   * phase of a transaction 1 or more i2c bus controllers attempted to perform
+   * an transaction and one of the i2c bus controllers, that isn't this one won
+   * out.
+   *
+   * @param p_address 7-bit address of the device you want to communicate with.
+   * To perform a transaction with a 10-bit address, this parameter must be the
+   * address upper byte of the 10-bit address OR'd with 0b1111'0000 (the 10-bit
+   * address indicator). The lower byte of the address must be contained in the
+   * first byte of the p_data_out span.
+   * @param p_data_out data to be written to the addressed device. Set this to a
+   * span with `size() == 0` in order to skip writing.
+   * @param p_data_in buffer to store read data from the addressed device. Set
+   * to nullptr with length 0 in order to skip reading.
+   * @throws hal::no_such_device - indicates that no devices on
+   * the bus acknowledge the address in this transaction, which could mean that
+   * the device is not connected to the bus, is not powered, not available to
+   * respond, broken or many other possible outcomes.
+   * @throws hal::io_error - indicates that the i2c lines were put into an
+   * invalid state during the transaction due to interference, misconfiguration,
+   * hardware fault, malfunctioning i2c peripheral or possibly something else.
+   * This tends to present a hardware issue and is usually not recoverable.
+   */
+  void transaction(hal::byte p_address,
+                   std::span<hal::byte const> p_data_out,
+                   std::span<hal::byte> p_data_in)
+  {
+    driver_transaction(p_address, p_data_out, p_data_in);
+  }
+
+  virtual ~i2c() = default;
+
+private:
+  virtual u32 driver_clock_rate() = 0;
+  virtual void driver_transaction(hal::byte p_address,
+                                  std::span<hal::byte const> p_data_out,
+                                  std::span<hal::byte> p_data_in) = 0;
+};
+}  // namespace v5
 }  // namespace hal

--- a/include/libhal/interrupt_pin.hpp
+++ b/include/libhal/interrupt_pin.hpp
@@ -125,4 +125,121 @@ private:
   virtual void driver_configure(settings const& p_settings) = 0;
   virtual void driver_on_trigger(hal::callback<handler> p_callback) = 0;
 };
+
+namespace v5 {
+/**
+ * @brief Digital interrupt pin hardware abstraction
+ *
+ * Use this to automatically call a function when a pin's state has
+ * transitioned.
+ *
+ * The transition states are:
+ *
+ *   - falling edge: the pin reads a transitions from HIGH to LOW
+ *   - rising edge: the pin reads a transitions from LOW to HIGH
+ *   - both: the pin reads any state change
+ */
+class interrupt_pin
+{
+public:
+  /**
+   * @brief The condition in which an interrupt it's triggered.
+   *
+   */
+  enum class trigger_edge : u8
+  {
+    /**
+     * @brief Trigger the interrupt when a pin transitions from HIGH voltage to
+     * LOW voltage.
+     *
+     */
+    falling = 0,
+    /**
+     * @brief Trigger the interrupt when a pin transitions from LOW voltage to
+     * HIGH voltage.
+     *
+     */
+    rising = 1,
+    /**
+     * @brief Trigger the interrupt when a pin transitions it state
+     *
+     */
+    both = 2,
+  };
+
+  /**
+   * @brief Generic settings for interrupt pins
+   *
+   */
+  struct settings
+  {
+    /**
+     * @brief Pull resistor for an interrupt pin.
+     *
+     * In general, it is highly advised to either set the pull resistor to
+     * something other than "none" or to attach an external pull up resistor to
+     * the interrupt pin in order to prevent random interrupt from firing.
+     */
+    pin_resistor resistor = pin_resistor::pull_up;
+
+    /**
+     * @brief The trigger condition that will signal the system to run the
+     * callback.
+     *
+     */
+    trigger_edge trigger = trigger_edge::rising;
+
+    /**
+     * @brief Enables default comparison
+     *
+     */
+    bool operator<=>(settings const&) const = default;
+  };
+
+  /**
+   * @brief Disambiguation tag object for interrupt pin handlers
+   *
+   */
+  struct handler_tag
+  {};
+
+  /**
+   * @brief Interrupt pin handler
+   *
+   * param p_state - if true state of the pin when the interrupt was triggered
+   * was HIGH, otherwise LOW
+   */
+  using handler = void(handler_tag, bool p_state);
+
+  /**
+   * @brief Configure the interrupt pin to match the settings supplied
+   *
+   * @param p_settings - settings to apply to interrupt pin
+   * @throws hal::operation_not_supported - if the settings could not be
+   * achieved.
+   */
+  void configure(settings const& p_settings)
+  {
+    driver_configure(p_settings);
+  }
+
+  /**
+   * @brief Set the callback for when the interrupt occurs
+   *
+   * Any state transitions before this function is called are lost.
+   *
+   * @param p_callback - function to execute when the trigger condition occurs.
+   */
+  void on_trigger(hal::callback<handler>& p_callback)
+  {
+    driver_on_trigger(p_callback);
+  }
+
+  virtual ~interrupt_pin() = default;
+
+private:
+  virtual void driver_configure(settings const& p_settings) = 0;
+  virtual void driver_on_trigger(hal::callback<handler>& p_callback) = 0;
+};
+}  // namespace v5
 }  // namespace hal

--- a/include/libhal/io_waiter.hpp
+++ b/include/libhal/io_waiter.hpp
@@ -14,6 +14,10 @@
 
 #pragma once
 
+#include <optional>
+
+#include "functional.hpp"
+
 namespace hal {
 /**
  * @brief An interface for customizing the behavior of drivers when they must
@@ -145,13 +149,13 @@ inline io_waiter& polling_io_waiter()
 {
   class polling_io_waiter_t : public hal::io_waiter
   {
-    void driver_wait()
+    void driver_wait() final
     {
       // Do nothing and allow the outer loop of the driver to poll its ready
       // flag.
       return;
     }
-    void driver_resume() noexcept
+    void driver_resume() noexcept final
     {
       // Since wait didn't do anything, neither does resume.
       return;
@@ -162,4 +166,191 @@ inline io_waiter& polling_io_waiter()
 
   return waiter;
 }
+namespace v5 {
+/**
+ * @brief An interface for customizing the behavior of drivers when they must
+ * wait for I/O to complete.
+ *
+ * All drivers that utilize DMA or interrupts to perform work while the CPU
+ * idles, should accept an io_waiter object as an input parameter and call the
+ * wait function when the CPU would normally spin in a polling loop for a
+ * considerable amount of time. This driver allows applications to optimize the
+ * amount of time the CPU spends doing meaningful work. Utilizing an io_waiter
+ * allows users of a driver to optimize the time the driver spends waiting for
+ * operations, specifically it can be used for context switching, putting the
+ * device to sleep, and doing small amounts of work.
+ *
+ * An exception to this rule would be drivers like non-dma spi or uart where the
+ * most efficient way to reach maximum throughput is to poll a register until
+ * the individual byte has been transferred.
+ *
+ * This is a standard interface for libhal drivers that allows operating systems
+ * and applications to customize the behavior of drivers when they wait for
+ * their I/O to complete. For example, if a driver performs some operation over
+ * DMA and must poll on a register or wait for an interrupt to fire before it
+ * can move on from that transaction, then the driver ought to have accepted an
+ * io_waiter from its constructor and called that object's `wait()` function.
+ */
+class io_waiter
+{
+public:
+  /**
+   * @brief Disambiguation tag object for io_waiter on wait callbacks
+   *
+   */
+  struct on_wait_tag
+  {};
+
+  using on_wait_handler = hal::callback<void(on_wait_tag)>;
+
+  /**
+   * @brief Execute this function when your driver is waiting on something
+   *
+   * The wait function should do one of the following:
+   *
+   * 1. Block the current thread of execution, if an RTOS or OS is used.
+   * 2. Put the system to sleep.
+   * 3. Perform a small chunk of work.
+   *
+   * Care should be taken when using an io_waiter for performing work. The work
+   * performed could exceed the time for a response or a transfer to complete.
+   * In some scenarios, this delay is harmless. But in some timing-sensitive
+   * situations, this could cause issues. Consider decoding MP3 data and
+   * streaming it to a DAC. Technically, the wait function could be used to
+   * prepare the next buffer for the DAC to stream, but if the decoding takes
+   * too long, then the DAC will be starved of data, the voltage stays the same
+   * until the decoding task is finished and a new stream of data is sent out.
+   * That break in the audio will sound like a pop or click and will make the
+   * audio choppy.
+   *
+   * If this API is used for doing chunks of work, then `resume()` can be an
+   * empty function as there is nothing needed to resume the current thread of
+   * execution.
+   *
+   * If this API is used for going to sleep, implement `resume()` if it is
+   * necessary to wake from sleep.
+   *
+   * If this API is used for context switching, block the current task using the
+   * lightest weight construct that the OS provides. That may be a semaphore, it
+   * could be a task notification, a signal, or a mutex.
+   *
+   * To use the `wait` API in your driver, provide a member boolean variable
+   * labelled something like `m_finished`. That flag will notify the driver code
+   * that the transaction has finished. The wait() function may return before
+   * the transaction is finished, so a loop is required.
+   *
+   * USAGE:
+   *
+   *      while (not m_finished) {
+   *          m_waiter.wait();
+   *      }
+   *
+   */
+  void wait()
+  {
+    driver_wait();
+  }
+
+  /**
+   * @brief Execute this function within an interrupt service routine to resume
+   *        normal operation.
+   *
+   * The resume function should do one of the following:
+   *
+   * 1. Unblock the previously blocked thread of execution.
+   * 2. Wake the device from sleep if necessary
+   *
+   * Care should be taken when unblocking a thread as it is likely that the
+   * resume api is being called in an interrupt context. As such the resume
+   * API MUST NOT THROW! The resume implementation should be as short as
+   * possible to achieve the action of resuming the thread of execution. Using
+   * resume to perform any lengthy work, calculations, or to control hardware is
+   * strictly forbidden as this can cause potential race conditions and
+   * starvation of the scheduler/application.
+   *
+   * The resume implementation should try as much as possible to ensure that no
+   * exceptions can be thrown within any api called within it. This should be
+   * avoided even if the terminate handler for the application is OS aware and
+   * only terminates the threads in which an exception was thrown. Even in this
+   * case, because resume can be called in an interrupt context it could have
+   * been fired at any point during any task, which would improperly terminate
+   * the wrong task.
+   *
+   */
+  void resume() noexcept
+  {
+    driver_resume();
+  }
+
+  /**
+   * @brief Inject a function to call before waiting on I/O
+   *
+   * This function allows application code to inject functionality into an I/O
+   * waiter before performing a wait. This is useful for stacking multiple
+   * waiting operations in a single thread OR throwing an exception out of an
+   * io_waiter if a deadline violation has occurred.
+   *
+   * @param p_callback - A function to be called before waiting on I/O
+   */
+  void on_wait(std::optional<on_wait_handler>& p_callback)
+  {
+    driver_on_wait(p_callback);
+  }
+
+  virtual ~io_waiter() = default;
+
+private:
+  virtual void driver_wait() = 0;
+  virtual void driver_resume() noexcept = 0;
+  virtual void driver_on_wait(std::optional<on_wait_handler>& p_callback) = 0;
+};
+
+/**
+ * @brief Returns a reference to a statically allocated polling io waiter
+ *
+ * Polling io waiter is a waiter that does nothing. It simply returns when wait
+ * or resume are called, causing the driver to poll its ready flag until it is
+ * completed. This should be used as a default io waiter type for drivers so
+ * the user does not have to manually pass the polling io waiter in the code.
+ * This waiter can be used in applications where polling is an acceptable option
+ * during a driver's waiting period.
+ *
+ * @return io_waiter& - reference to statically allocated polling io waiter
+ * object.
+ */
+inline io_waiter& polling_io_waiter()
+{
+  class polling_io_waiter_t : public hal::v5::io_waiter
+  {
+    void driver_wait() override
+    {
+      if (m_callback) {
+        m_callback.value()(on_wait_tag{});
+      }
+
+      // Do nothing and allow the outer loop of the driver to poll its ready
+      // flag.
+      return;
+    }
+
+    void driver_resume() noexcept override
+    {
+      // Since wait didn't do anything, neither does resume.
+      return;
+    }
+
+    void driver_on_wait(
+      std::optional<hal::callback<void(on_wait_tag)>>& p_callback) override
+    {
+      m_callback = p_callback;
+    }
+
+    std::optional<hal::callback<void(on_wait_tag)>> m_callback;
+  };
+
+  static polling_io_waiter_t waiter;
+
+  return waiter;
+}
+}  // namespace v5
 }  // namespace hal

--- a/include/libhal/motor.hpp
+++ b/include/libhal/motor.hpp
@@ -16,6 +16,8 @@
 
 #include <algorithm>
 
+#include "units.hpp"
+
 namespace hal {
 /**
  * @brief Hardware abstraction for an open loop rotational actuator
@@ -71,4 +73,60 @@ public:
 private:
   virtual void driver_power(float p_power) = 0;
 };
+
+namespace v5 {
+/**
+ * @brief Hardware abstraction for an open loop rotational actuator
+ *
+ * The motor interface can represent a variety of things such as:
+ *
+ *   - A driver for motor controller IC like the DRV8801
+ *   - A driver for a motor with integrated controller & serial interface
+ *   - A unidirectional motor controlled by a single transistor
+ *   - A servo with open loop motor control
+ *
+ */
+class motor
+{
+public:
+  /**
+   * @brief Apply power to the motor
+   *
+   * Power is a percentage and thus cannot be used as a way to gauge how fast
+   * the motor is moving. In general applying more power means to increase speed
+   * and/or torque to the motor.
+   *
+   * - 0% power would mean that no power is being applied to the motor. In this
+   *   situation an unloaded motor will not move. 0% power does not guarantee
+   *   that the motor will hold its position. These specifics depend greatly on
+   *   the type of motor used and careful selection of motor and motor driver
+   *   are important for applications using this interface.
+   *
+   * - 100% power means that the maximum available of power is being applied to
+   *   the motor. As an example, if the max voltage of a DC brushed motor's
+   *   power supply is 12V, then 12V would be supplied to this motor.
+   *
+   * - 50% power would mean that half of the available power is being applied to
+   *   the motor. Using the same example, in this case 6V would be applied to
+   *   the motor either as a DC constant voltage or via PWM at 50% duty cycle.
+   *
+   * - Negative values will cause the motor to move in the opposite
+   *   direction as positive values. In the event that motor driver can *
+   *   only go in one direction, this function should clamp the power applied to
+   *   0%.
+   *
+   * @param p_power - Percentage of power to apply to the motor from -32'768 to
+   * 32'767, -100% to 100%, respectively.
+   */
+  void power(i16 p_power)
+  {
+    return driver_power(p_power);
+  }
+
+  virtual ~motor() = default;
+
+private:
+  virtual void driver_power(i16 p_power) = 0;
+};
+}  // namespace v5
 }  // namespace hal

--- a/include/libhal/serial.hpp
+++ b/include/libhal/serial.hpp
@@ -20,8 +20,173 @@
 #include "units.hpp"
 
 namespace hal {
+namespace v5 {
+
 /**
- * @deprecated Use `zero_copy_serial` instead for better performance
+ * @brief Hardware abstract interface for the serial communication protocol
+ *
+ * Use this interface for hardware that implements a serial protocol like UART,
+ * RS232, RS485 and others that use a similar communication protocol but may use
+ * different voltage schemes.
+ *
+ * This interface only works 8-bit serial data frames.
+ *
+ * Due to the asynchronous and unformatted nature of serial communication
+ * protocols, all implementations of serial devices must be buffered. Buffered,
+ * in this case, is defined as automatic storage of received bytes without
+ * direct application intervention.
+ *
+ * All implementations MUST allow the user to supply their own buffer of
+ * arbitrary size up to the limits of what hardware can support. This allows a
+ * developer the ability to tailored the buffer size to the needs of the
+ * application.
+ *
+ * Examples of buffering schemes are:
+ *
+ * - Using DMA to copy data from a serial peripheral to a region of memory
+ * - Using interrupts when a serial peripheral's queue has filled to a point.
+ *   Refrain from using interrupts if the peripheral's byte queue is only of
+ *   size 1. This is bad for runtime performance and can result in missed bytes.
+ *
+ */
+class serial
+{
+public:
+  /// Generic settings for a standard serial device.
+  struct settings
+  {
+    /// Set of available stop bits options
+    enum class stop_bits : uint8_t
+    {
+      one = 0,
+      two,
+    };
+
+    /// Set of parity bit options
+    enum class parity : uint8_t
+    {
+      /// Disable parity bit as part of the frame
+      none = 0,
+      /// Enable parity and set 1 (HIGH) when the number of bits is odd
+      odd,
+      /// Enable parity and set 1 (HIGH) when the number of bits is even
+      even,
+      /// Enable parity bit and always return 1 (HIGH) for ever frame
+      forced1,
+      /// Enable parity bit and always return 0 (LOW) for ever frame
+      forced0,
+    };
+
+    /// The operating speed of the baud rate (in units of bits per second)
+    u32 baud_rate = 115200;
+
+    /// Number of stop bits for each frame
+    stop_bits stop = stop_bits::one;
+
+    /// Parity bit type for each frame
+    parity parity = parity::none;
+
+    /**
+     * @brief Enables default comparison
+     *
+     */
+    bool operator<=>(settings const&) const = default;
+  };
+  /**
+   * @brief Configure serial to match the settings supplied
+   *
+   * Implementing drivers must verify if the settings can be applied to hardware
+   * before modifying the hardware. This will ensure that if this operation
+   * fails, the state of the serial device has not changed.
+   *
+   * @param p_settings - settings to apply to serial driver
+   * @throws hal::operation_not_supported - if the settings could not be
+   * achieved.
+   */
+  void configure(settings const& p_settings)
+  {
+    driver_configure(p_settings);
+  }
+
+  /**
+   * @brief Write data to the transmitter line of the serial port
+   *
+   * @param p_data - data to be transmitted over the serial port
+   */
+  void write(std::span<hal::byte const> p_data)
+  {
+    driver_write(p_data);
+  }
+
+  /**
+   * @brief Returns this serial driver's receive buffer
+   *
+   * Use this along with the receive_cursor() in order to determine if new data
+   * has been read into the receive buffer. See the docs for `receive_cursor()`
+   * for more details.
+   *
+   * @return std::span<hal::byte const> - a const span to the receive buffer
+   * used by the serial port. Calling `size()` on the span will always
+   * return a value of at least 1.
+   */
+  [[nodiscard]] std::span<hal::byte const> receive_buffer()
+  {
+    return driver_receive_buffer();
+  }
+
+  /**
+   * @brief Returns the current write position of the circular receive buffer
+   *
+   * Receive cursor represents the position where the next byte of data will be
+   * written in to the receive buffer. This position advances as new data
+   * arrives. To determine how much new data has arrived, store the previous
+   * cursor position and compare it with the current cursor position, accounting
+   * for buffer wraparound.
+   *
+   * The cursor value will ALWAYS follow this equation:
+   *
+   *          0 <= cursor && cursor < receive_buffer().size()
+   *
+   * Thus making the following expression valid memory access:
+   *
+   *         serial.receive_buffer()[ serial.cursor() ];
+   *
+   * Just note that just because it is valid does not mean that there is useful
+   * information at this position.
+   *
+   * Example:
+   *
+   *   auto old_head = port.receive_cursor();
+   *   // ... wait for new data ...
+   *   auto new_head = port.receive_cursor();
+   *   // Account for circular wraparound when calculating bytes received
+   *   auto buffer_size = port.receive_buffer().size();
+   *   auto bytes_received = (new_head + buffer_size - old_head) % buffer_size;
+   *
+   * Use this along with receive_buffer() to access newly received data. The
+   * data between your last saved position and the current cursor position
+   * represents the newly received bytes. When reading the data, remember that
+   * it may wrap around from the end of the buffer back to the beginning.
+   *
+   * @return std::size_t - position of the write cursor for the circular buffer
+   */
+  [[nodiscard]] std::size_t receive_cursor()
+  {
+    return driver_cursor();
+  }
+
+  virtual ~serial() = default;
+
+private:
+  virtual void driver_configure(settings const& p_settings) = 0;
+  virtual void driver_write(std::span<hal::byte const> p_data) = 0;
+  virtual std::span<hal::byte const> driver_receive_buffer() = 0;
+  virtual std::size_t driver_cursor() = 0;
+};
+}  // namespace v5
+
+/**
+ * @deprecated Use `v5::serial` instead for better performance
  * @brief Hardware abstract interface for the serial communication protocol
  *
  * Use this interface for hardware that implements a serial protocol like UART,

--- a/include/libhal/timer.hpp
+++ b/include/libhal/timer.hpp
@@ -93,4 +93,89 @@ private:
   virtual void driver_schedule(hal::callback<void(void)> p_callback,
                                hal::time_duration p_delay) = 0;
 };
+
+namespace v5 {
+/**
+ * @brief Timer hardware abstraction interface.
+ *
+ * Use this interface for devices and peripherals that have timer like
+ * capabilities, such that, when a timer's time has expired, an event,
+ * interrupt, or signal is generated.
+ *
+ * Timer drivers tick period must be an integer multiple of 1 nanosecond,
+ * meaning that the only tick period allowed are 1ns, 2ns, up to the maximum
+ * holdable in a std::chrono::nanosecond type. sub-nanosecond tick periods are
+ * not allowed.
+ *
+ */
+class timer
+{
+public:
+  /**
+   * @brief Disambiguation tag object for timer callbacks
+   *
+   */
+  struct schedule_tag
+  {};
+
+  /**
+   * @brief Determine if the timer is currently running
+   *
+   * @return true - if a callback has been scheduled and has not been invoked
+   * yet, false otherwise.
+   */
+  [[nodiscard]] bool is_running()
+  {
+    return driver_is_running();
+  }
+
+  /**
+   * @brief Stops a scheduled event from happening.
+   *
+   * Does nothing if the timer is not currently running.
+   *
+   * Note that there must be sufficient time between the this call finishing and
+   * the scheduled event's termination. If this call is too close to when the
+   * schedule event expires, this function may not complete before the hardware
+   * calls the callback.
+   */
+  void cancel()
+  {
+    driver_cancel();
+  }
+
+  /**
+   * @brief Schedule an callback be be executed after the delay time
+   *
+   * If this is called and the timer has already scheduled an event (in other
+   * words, `is_running()` returns true), then the previous scheduled event will
+   * be canceled and the new scheduled event will be started.
+   *
+   * If the delay time result in a tick period of 0, then the timer will execute
+   * after 1 tick period. For example, if the tick period is 1ms and the
+   * requested time delay is 500us, then the event will be scheduled for 1ms.
+   *
+   * If the tick period is 1ms and the requested time is 2.5ms then the event
+   * will be scheduled after 2 tick periods or in 2ms.
+   *
+   * @param p_callback - callback function to be called when the timer expires
+   * @param p_delay - the amount of time until the timer expires
+   * @throws hal::argument_out_of_domain - if p_interval is greater than what
+   * can be cannot be achieved.
+   */
+  void schedule(hal::callback<void(schedule_tag)>& p_callback,
+                hal::time_duration p_delay)
+  {
+    driver_schedule(p_callback, p_delay);
+  }
+
+  virtual ~timer() = default;
+
+private:
+  virtual bool driver_is_running() = 0;
+  virtual void driver_cancel() = 0;
+  virtual void driver_schedule(hal::callback<void(schedule_tag)>& p_callback,
+                               hal::time_duration p_delay) = 0;
+};
+}  // namespace v5
 }  // namespace hal

--- a/include/libhal/zero_copy_serial.hpp
+++ b/include/libhal/zero_copy_serial.hpp
@@ -22,6 +22,7 @@
 
 namespace hal {
 /**
+ * @deprecated Use `v5::serial` instead for better performance
  * @brief Hardware abstract interface for the serial communication protocol
  *
  * Use this interface for hardware that implements a serial protocol like UART,


### PR DESCRIPTION
The v5 namespace was added for ABI versioning. When we migrate to libhal 5.0.0, we will delete everything from libhal 4, and make all namespaces inline v5 for everthing.