### PR TITLE
:truck: Rename interrupt classes

### DIFF
--- a/include/libhal/can.hpp
+++ b/include/libhal/can.hpp
@@ -1182,7 +1182,7 @@ private:
  * message is received. If message filtering is enabled, then the callback will
  * only be for messages received through the filter.
  */
-class can_interrupt
+class can_message_interrupt
 {
 public:
   /**
@@ -1221,7 +1221,7 @@ public:
     driver_on_receive(p_callback);
   }
 
-  virtual ~can_interrupt() = default;
+  virtual ~can_message_interrupt() = default;
 
 private:
   virtual void driver_on_receive(optional_receive_handler& p_callback) = 0;

--- a/include/libhal/timed_interrupt.hpp
+++ b/include/libhal/timed_interrupt.hpp
@@ -1,0 +1,92 @@
+// Copyright 2024 - 2025 Khalil Estell and the libhal contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "functional.hpp"
+#include "units.hpp"
+
+namespace hal::v5 {
+/**
+ * @brief An abstraction for hardware timed interrupts.
+ *
+ * Use this interface for devices and peripherals that have timer like
+ * capabilities, such that, when a timer's time has expired, an event,
+ * interrupt, or signal is generated.
+ *
+ * Timer drivers tick period must be an integer multiple of 1 nanosecond,
+ * meaning that the only tick period allowed are 1ns, 2ns, up to the maximum
+ * holdable in a std::chrono::nanosecond type. sub-nanosecond tick periods are
+ * not allowed.
+ *
+ */
+class timed_interrupt
+{
+public:
+  /**
+   * @brief Disambiguation tag object for timer callbacks
+   *
+   */
+  struct schedule_tag
+  {};
+
+  /**
+   * @brief Handler called when the timed interrupt triggers
+   */
+  using optional_handler = std::optional<hal::callback<void(schedule_tag)>>;
+
+  /**
+   * @brief Determine if the timer is currently pending
+   *
+   * @return true - if a callback has been scheduled and has not been invoked
+   * yet, false otherwise.
+   */
+  [[nodiscard]] bool scheduled()
+  {
+    return driver_scheduled();
+  }
+
+  /**
+   * @brief Schedule an callback be be executed after the delay time
+   *
+   * If this is called and the timer has already scheduled an event (in other
+   * words, `is_running()` returns true), then the previous scheduled event will
+   * be canceled and the new scheduled event will be started.
+   *
+   * If the delay time result in a tick period of 0, then the timer will execute
+   * after 1 tick period. For example, if the tick period is 1ms and the
+   * requested time delay is 500us, then the event will be scheduled for 1ms.
+   *
+   * If the tick period is 1ms and the requested time is 2.5ms then the event
+   * will be scheduled after 2 tick periods or in 2ms.
+   *
+   * @param p_callback - callback function to be called when the timer expires.
+   * Pass std::nullopt in order to
+   * @param p_delay - the amount of time until the timer expires
+   * @throws hal::argument_out_of_domain - if p_interval is greater than what
+   * can be cannot be achieved.
+   */
+  void schedule(optional_handler const& p_callback, hal::time_duration p_delay)
+  {
+    driver_schedule(p_callback, p_delay);
+  }
+
+  virtual ~timed_interrupt() = default;
+
+private:
+  virtual bool driver_scheduled() = 0;
+  virtual void driver_schedule(optional_handler const& p_callback,
+                               hal::time_duration p_delay) = 0;
+};
+}  // namespace hal::v5


### PR DESCRIPTION
- rename timer to v5::timed_interrupt
- rename interrupt_pin to v5::edge_triggered_interrupt
- rename can_interrupt to v5::can_message_interrupt

The purpose of this is to make the names of the interrupt classes consistent and explanatory. Now when spoken developers can speak of these things as interrupt types. We may say, "Do we need a timed interrupt or an can_message interrupt. Can we rely on the can messages to ensure we wake up often enough? Or do we need something there to periodically wake up the system to check for work to be done."

`hal::adc_conversion_complete_interrupt` may exist but most likely we'd make an `adc_interrupt` interface with the necessary number of callback installing functions.