### PR TITLE
:sparkles: `enable_strong_from_this<T>` & `strong_ptr_only_token`

### DIFF
--- a/include/libhal/error.hpp
+++ b/include/libhal/error.hpp
@@ -607,6 +607,21 @@ struct unknown : public exception
 
 /**
  * @ingroup Error
+ * @brief Raised when a weak_ptr is accessed for an object that has been
+ * destroyed.
+ *
+ */
+class bad_weak_ptr : public hal::exception
+{
+public:
+  bad_weak_ptr(void* p_weak_ptr_instance)
+    : hal::exception(std::errc::bad_address, p_weak_ptr_instance)
+  {
+  }
+};
+
+/**
+ * @ingroup Error
  * @brief libhal function for throwing exceptions with static analysis
  *
  * The types that can be thrown must follow these rules:


### PR DESCRIPTION
- `enable_strong_from_this<T>`: implements the same behavior as `std::enabled_shared_from_this<T>` but to `hal::strong_ptr<T>`
- `strong_ptr_only_token`: Provides a mechanism to prevent public constructors of a class from being constructible outside of `make_strong_ptr`. As a policy drivers should have this parameter type as their first parameter to ensure their driver is has managed lifetime.