### PR TITLE
:sparkles: Add `hal::v5::scatter_span`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,12 +50,12 @@ libhal_unit_test(SOURCES
   tests/current_sensor.test.cpp
   tests/stream_dac.test.cpp
   tests/lock.test.cpp
-  tests/experimental/usb.test.cpp
   tests/zero_copy_serial.test.cpp
   tests/buffered_can.test.cpp
   tests/pointers.test.cpp
   tests/circular_buffer.test.cpp
   tests/allocated_buffer.test.cpp
+  tests/scatter_span.test.cpp
   tests/main.test.cpp
 
   PACKAGES

--- a/include/libhal/scatter_span.hpp
+++ b/include/libhal/scatter_span.hpp
@@ -1,0 +1,172 @@
+// Copyright 2024 - 2025 Khalil Estell and the libhal contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <array>
+#include <span>
+
+#include "units.hpp"
+
+namespace hal::v5 {
+/**
+ * @brief A view over several non‑contiguous memory blocks.
+ *
+ * `scatter_span<T>` is a alias for `std::span<std::span<T> const>`.  Each
+ * element of the outer span points to a distinct block of objects of type `T`.
+ * The blocks may come from any memory pool (stack, heap, ROM, etc.) and need
+ * not be contiguous with respect to one another. This type is meant for
+ * facilitating the reading and writing of multiple non-contiguous blocks of
+ * memory to and from peripheral or device memory. The order is considered
+ * constant from the view's point of view since interface APIs taking this type
+ * should not change the order of the passed span.
+ *
+ * @tparam T The type of the objects stored in each sub‑span.
+ *
+ * Typical use case:
+ *
+ *   ```cpp
+ *   std::array<hal::byte, 5>  buf1{...};
+ *   std::array<hal::byte, 3>  buf2{...};
+ *
+ *   // `sp` is `std::array<std::span<hal::byte>, 2>`.
+ *   auto sp = hal::make_scatter_array(buf1, buf2);
+ *   ```
+ *
+ * @note **Lifetime** – `scatter_span` does **not** own its data.  All
+ * spans it contains must outlive the `scatter_span` object. It is, therefor,
+ * recommended to only use this as an input parameter to functions. Such
+ * functions SHOULD NOT capture the information outside of their scope, (e.g.
+ * class member variable, global/static memory, heap memory).
+ *
+ * @see make_scatter_array()  // helper that constructs the array
+ * @see to_scatter_byte_array()  // convenient overload for `hal::byte`
+ */
+template<class T>
+using scatter_span = std::span<std::span<T> const>;
+
+/**
+ * @brief Create an `std::array` of `std::span<T>` from a variable‑length list
+ * of arguments.
+ *
+ * The function accepts any number of arguments that can be converted to
+ * `std::span<T>`.  Commonly this means:
+ *
+ *   * a `std::span<T>`,
+ *   * a raw pointer and a size (`T const*`, `size_t`),
+ *   * an array (`std::array<T, N>`, `T[N]`, `std::vector<T>`, etc.).
+ *
+ * The return type is an `std::array<std::span<T>, N>` where
+ * `N == sizeof...(Args)`. The returned array is a compile‑time fixed‑size
+ * container, making it ideal for APIs that accept a scatter view with a known
+ * number of elements.
+ *
+ * @tparam T    The element type of the sub‑spans.
+ * @tparam Args Variadic list of arguments convertible to `std::span<T>`.
+ * @param args  The source data blocks.
+ * @return constexpr auto  An `std::array` of `std::span<T>`.
+ *
+ * @par Example
+ *
+ * ```cpp
+ * std::array<hal::byte, 4> a{1,2,3,4};
+ * std::vector<hal::byte> v{5,6,7};
+ *
+ * auto arr = hal::make_scatter_array<hal::byte>(a, v);
+ * // arr[0] → span over a
+ * // arr[1] → span over v
+ * ```
+ *
+ * @note **Thread‑safety** – The function itself is thread‑safe.
+ * The resulting spans simply reference the original data, so
+ * thread‑safety depends on the callers’ use of the underlying data.
+ *
+ * @note **Lifetime** – The returned `std::array` holds spans that
+ * reference the caller‑supplied data. The caller must guarantee that
+ * those data outlive the array’s use.
+ */
+template<class T, class... Args>
+constexpr auto make_scatter_array(Args&&... args)
+{
+  return std::array<std::span<T>, sizeof...(Args)>{ std::span<T>(
+    std::forward<Args>(args))... };
+}
+
+/**
+ * @brief Convenience overload that creates a scatter array for
+ * `hal::byte` (i.e. raw bytes).
+ *
+ * This helper is useful when the API deals with byte buffers,
+ * such as USB or serial transmission functions.
+ *
+ * @tparam Args Variadic list of arguments convertible to
+ *              `std::span<hal::byte const>`.
+ * @param args  The source byte blocks.
+ * @return constexpr auto  An `std::array<std::span<hal::byte const>, N>`.
+ *
+ * @par Example
+ *
+ * ```cpp
+ * std::array<hal::byte, 4> a{1,2,3,4};
+ * std::span<const hal::byte> s{a.data(), a.size()};
+ *
+ * auto arr = hal::make_scatter_bytes(a, s);
+ * // arr[0] → span over a
+ * // arr[1] → span over s
+ * ```
+ *
+ * @see make_scatter_array()  // generic form
+ */
+template<class... Args>
+constexpr auto make_scatter_bytes(Args&&... args)
+{
+  return make_scatter_array<hal::byte const>(std::forward<Args>(args)...);
+}
+
+/**
+ * @brief Convenience overload that creates a readable scatter array for
+ * `hal::byte` (i.e. raw bytes).
+ *
+ * This helper is useful when the API deals with byte buffers, such as USB or
+ * serial transmission functions.
+ *
+ * @tparam Args - Variadic list of arguments convertible to
+ *               `std::span<hal::byte>`.
+ * @param args - The source byte blocks.
+ * @return constexpr auto  An `std::array<std::span<hal::byte>, N>`.
+ *
+ * @par Example
+ *
+ * ```cpp
+ * std::array<hal::byte, 4> a{1,2,3,4};
+ * std::span<hal::byte> s{a.data(), a.size()};
+ *
+ * auto arr = hal::make_writable_scatter_bytes(a, s);
+ * // arr[0] → span over a
+ * // arr[1] → span over s
+ *
+ * std::span<hal::byte const> const_data{a.data(), a.size()};
+ *
+ * // ERROR: ❌ one of the arrays is const and not writeable.
+ * auto arr = hal::make_writable_scatter_bytes(a, s, const_data);
+ * ```
+ *
+ * @see make_scatter_array()  // generic form
+ */
+template<class... Args>
+constexpr auto make_writable_scatter_bytes(Args&&... args)
+{
+  return make_scatter_array<hal::byte>(std::forward<Args>(args)...);
+}
+}  // namespace hal::v5

--- a/tests/scatter_span.test.cpp
+++ b/tests/scatter_span.test.cpp
@@ -1,0 +1,108 @@
+// Copyright 2024 - 2025 Khalil Estell and the libhal contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstring>
+
+#include <array>
+#include <type_traits>
+#include <vector>
+
+#include <libhal/scatter_span.hpp>
+
+#include <boost/ut.hpp>
+
+namespace hal {
+namespace {
+struct multi_buffer
+{
+  std::array<int, 5> arr = { 1, 2, 3, 4, 5 };
+  std::vector<int> vec = { 10, 20, 30, 40 };
+};
+}  // namespace
+
+boost::ut::suite scatter_api_test = []() {
+  using namespace boost::ut;
+
+  "make_scatter_array - generic"_test = [] {
+    multi_buffer buf;
+    constexpr auto expected_length = 2;
+    auto arr = hal::v5::make_scatter_array<int const>(buf.arr, buf.vec);
+
+    static_assert(
+      std::is_same_v<decltype(arr),
+                     std::array<std::span<int const>, expected_length>>,
+      "make_scatter_array must return std::array<std::span<T const>, "
+      "expected_length>");
+
+    expect(that % expected_length == arr.size());
+    expect(that % buf.arr.size() == arr[0].size());
+    expect(that % buf.vec.size() == arr[1].size());
+    expect(that % arr[0].data() == buf.arr.data());
+    expect(that % arr[1].data() == buf.vec.data());
+  };
+
+  "make_scatter_bytes - const bytes"_test = [] {
+    std::array<hal::byte, 4> a{ 0x1, 0x2, 0x3, 0x4 };
+    std::vector<hal::byte> v{ 0x5, 0x6 };
+    constexpr static std::array<hal::byte, 3> static_arr{ 0xA, 0xB, 0xC };
+
+    auto arr = hal::v5::make_scatter_bytes(a, v, static_arr);
+    auto scatter_span = hal::v5::scatter_span<hal::byte const>(arr);
+
+    static_assert(
+      std::is_same_v<decltype(arr), std::array<std::span<hal::byte const>, 3>>,
+      "make_scatter_bytes must return array of const byte spans");
+
+    expect(that % 0x1 == arr[0][0]);
+    expect(that % 0x4 == arr[0][3]);
+    expect(that % 0x5 == arr[1][0]);
+    expect(that % 0x6 == arr[1][1]);
+    expect(that % 0xA == arr[2][0]);
+    expect(that % 0xB == arr[2][1]);
+    expect(that % 0xC == arr[2][2]);
+
+    expect(that % 0x1 == scatter_span[0][0]);
+    expect(that % 0x4 == scatter_span[0][3]);
+    expect(that % 0x5 == scatter_span[1][0]);
+    expect(that % 0x6 == scatter_span[1][1]);
+    expect(that % 0xA == scatter_span[2][0]);
+    expect(that % 0xB == scatter_span[2][1]);
+    expect(that % 0xC == scatter_span[2][2]);
+
+    using element_type = std::remove_reference_t<decltype(arr[0][0])>;
+    static_assert(std::is_const_v<element_type>, "Element should be non-const");
+  };
+
+  "make_writable_scatter_bytes - mutable bytes"_test = [] {
+    std::array<hal::byte, 3> a{ 0x7, 0x8, 0x9 };
+    std::vector<hal::byte> v{ 0xA, 0xB };
+
+    auto arr = hal::v5::make_writable_scatter_bytes(a, v);
+    auto scatter_span = hal::v5::scatter_span<hal::byte>(arr);
+
+    static_assert(
+      std::is_same_v<decltype(arr), std::array<std::span<hal::byte>, 2>>,
+      "make_writable_scatter_bytes must return array of mutable byte spans");
+
+    arr[0][0] = 0xC;
+
+    expect(that % 0xC == arr[0][0]);
+    expect(that % 0xC == a[0]);
+    expect(that % 0xC == scatter_span[0][0]);
+
+    static_assert(not std::is_const_v<decltype(arr[0][0])>,
+                  "Element should be non-const");
+  };
+};
+}  // namespace hal


### PR DESCRIPTION
Scatter span will be the defacto-standard for all APIs that deal with arrays of data in v5. At its core it is a span-of-spans with type `std::span<std::span<T> const>`. This allows code to order disjoint non-contiguous regions of memory and pass all of them to an API to be transmitted or filled.

## **Motivation:**

Previously this required calling APIs for each disjoint memory block OR allocating a region of memory to buffer the disjoint memory regions into a single contiguous block of memory. The first option means that the code will have to perform multiple calls to an API which can result time gaps between each segment of memory (transmitted or received). The second allocates additional memory the size of all blocks of memory (or in chunk) in order to perform this operation.

Rather than copy data or perform multiple calls, we can allocate an array of spans (in general should be smaller), preferably on the stack, and send that to API.