### PR TITLE
minor: defaulted default constructors of optional_ptr

### DIFF
--- a/include/libhal/pointers.hpp
+++ b/include/libhal/pointers.hpp
@@ -1046,16 +1046,12 @@ public:
   /**
    * @brief Default constructor creates a disengaged optional
    */
-  constexpr optional_ptr() noexcept
-  {
-  }
+  constexpr optional_ptr() noexcept = default;
 
   /**
    * @brief Constructor for nullptr (creates a disengaged optional)
    */
-  constexpr optional_ptr(std::nullptr_t) noexcept
-  {
-  }
+  constexpr optional_ptr(std::nullptr_t) noexcept = default;
 
   /**
    * @brief Move constructor is deleted

--- a/include/libhal/pointers.hpp
+++ b/include/libhal/pointers.hpp
@@ -1051,7 +1051,9 @@ public:
   /**
    * @brief Constructor for nullptr (creates a disengaged optional)
    */
-  constexpr optional_ptr(std::nullptr_t) noexcept = default;
+  constexpr optional_ptr(std::nullptr_t) noexcept
+  {
+  }
 
   /**
    * @brief Move constructor is deleted


### PR DESCRIPTION
Exactly as it looks. Not sure if I've missed any other default constructors.