### PR TITLE
:bug: (patch) Insert v5::make_allocated_buffer into hal namespace

### DIFF
--- a/v4/include/libhal/allocated_buffer.hpp
+++ b/v4/include/libhal/allocated_buffer.hpp
@@ -589,5 +589,6 @@ template<typename T>
 }  // namespace hal::v5
 
 namespace hal {
-using hal::v5::allocated_buffer;
-}
+using v5::allocated_buffer;
+using v5::make_allocated_buffer;
+}  // namespace hal

--- a/v4/tests/allocated_buffer.test.cpp
+++ b/v4/tests/allocated_buffer.test.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/ut.hpp>
 
-namespace hal::v5 {
+namespace hal {
 namespace {
 // Default test allocator
 std::pmr::monotonic_buffer_resource test_buffer{ 4096 };
@@ -291,4 +291,4 @@ boost::ut::suite<"allocated_buffer_test"> allocated_buffer_test = []() {
     }
   };
 };
-}  // namespace hal::v5
+}  // namespace hal

--- a/v4/tests/circular_buffer.test.cpp
+++ b/v4/tests/circular_buffer.test.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/ut.hpp>
 
-namespace hal::v5 {
+namespace hal {
 namespace {
 // Default test allocator
 std::pmr::monotonic_buffer_resource test_buffer{ 4096 };
@@ -260,4 +260,4 @@ boost::ut::suite<"circular_buffer_test"> circular_buffer_test = []() {
       << "All instances should be destroyed when buffer goes out of scope";
   };
 };
-}  // namespace hal::v5
+}  // namespace hal

--- a/v4/tests/pointers.test.cpp
+++ b/v4/tests/pointers.test.cpp
@@ -578,7 +578,7 @@ public:
   }
 
   // Private constructor - only make_strong_ptr can access
-  explicit restricted_class(hal::v5::strong_ptr_only_token, int p_value = 0)
+  explicit restricted_class(hal::strong_ptr_only_token, int p_value = 0)
     : m_value(p_value)
   {
   }
@@ -610,7 +610,7 @@ public:
     return strong_from_this();
   }
 
-  explicit fully_managed_class(hal::v5::strong_ptr_only_token, int p_value = 0)
+  explicit fully_managed_class(hal::strong_ptr_only_token, int p_value = 0)
     : m_value(p_value)
   {
   }

--- a/v4/tests/pointers.test.cpp
+++ b/v4/tests/pointers.test.cpp
@@ -21,7 +21,7 @@
 #include <boost/ut.hpp>
 
 // NOLINTBEGIN(performance-unnecessary-copy-initialization)
-namespace hal::v5 {
+namespace hal {
 namespace {
 // Base class for testing polymorphism
 class base_class
@@ -510,12 +510,12 @@ boost::ut::suite<"optional_ptr_test"> optional_ptr_test =
       };
   };
 // NOLINTEND(performance-unnecessary-copy-initialization)
-}  // namespace hal::v5
+}  // namespace hal
 
 // Additional unit tests for new features: enable_strong_from_this,
 // strong_ptr_only, and optional_ptr improvements
 
-namespace hal::v5 {
+namespace hal {
 namespace {
 
 // Test class that uses enable_strong_from_this
@@ -920,4 +920,4 @@ boost::ut::suite<"bad_weak_ptr_test"> bad_weak_ptr_test = []() {
   };
 };
 
-}  // namespace hal::v5
+}  // namespace hal

--- a/v4/tests/scatter_span.test.cpp
+++ b/v4/tests/scatter_span.test.cpp
@@ -22,7 +22,7 @@
 
 #include <boost/ut.hpp>
 
-namespace hal::v5 {
+namespace hal {
 namespace {
 struct multi_buffer
 {
@@ -189,4 +189,4 @@ boost::ut::suite<"scatter_api_test"> scatter_api_test = []() {
     expect(that % (se == sg));
   };
 };
-}  // namespace hal::v5
+}  // namespace hal

--- a/v4/tests/usb.test.cpp
+++ b/v4/tests/usb.test.cpp
@@ -19,7 +19,7 @@
 
 #include <boost/ut.hpp>
 
-namespace hal::v5::usb {
+namespace hal::usb {
 
 namespace {
 
@@ -663,9 +663,9 @@ boost::ut::suite<"usb_specific_endpoint_test"> specific_endpoint_test = []() {
     expect(that % buffer2.size() == endpoint.m_read_buffer[1].size());
   };
 };
-}  // namespace hal::v5::usb
+}  // namespace hal::usb
 
-namespace hal::v5::usb {
+namespace hal::usb {
 
 namespace {
 
@@ -805,4 +805,4 @@ boost::ut::suite<"usb_interface_test"> usb_interface_test = []() {
     expect(command == iface.handle_request_setup);
   };
 };
-}  // namespace hal::v5::usb
+}  // namespace hal::usb


### PR DESCRIPTION
Removed `v5` from unit tests to confirm that migration to `hal` works. `v5::make_allocated_buffer` was missing from that list.