### PR TITLE
🩹 (patch) Default the default constructor of optional_ptr

### DIFF
--- a/v4/include/libhal/pointers.hpp
+++ b/v4/include/libhal/pointers.hpp
@@ -1047,12 +1047,16 @@ public:
   /**
    * @brief Default constructor creates a disengaged optional
    */
-  constexpr optional_ptr() noexcept = default;
+  constexpr optional_ptr() noexcept
+    : m_raw_ptrs({ nullptr, nullptr })
+  {
+  }
 
   /**
    * @brief Constructor for nullptr (creates a disengaged optional)
    */
   constexpr optional_ptr(std::nullptr_t) noexcept
+    : m_raw_ptrs({ nullptr, nullptr })
   {
   }
 

--- a/v4/include/libhal/pointers.hpp
+++ b/v4/include/libhal/pointers.hpp
@@ -1052,7 +1052,9 @@ public:
   /**
    * @brief Constructor for nullptr (creates a disengaged optional)
    */
-  constexpr optional_ptr(std::nullptr_t) noexcept = default;
+  constexpr optional_ptr(std::nullptr_t) noexcept
+  {
+  }
 
   /**
    * @brief Move constructor is deleted

--- a/v4/include/libhal/pointers.hpp
+++ b/v4/include/libhal/pointers.hpp
@@ -1048,15 +1048,18 @@ public:
    * @brief Default constructor creates a disengaged optional
    */
   constexpr optional_ptr() noexcept
-    : m_raw_ptrs({ nullptr, nullptr })
   {
+    // This constructor cannot be replaced with a `= default` because of the
+    // strong_ptr union member. strong_ptr doesn't have a default constructor
+    // and thus, prevents the `= default` from being used. This constructor, may
+    // look like its doing nothing but its allowing the m_raw_ptrs to be default
+    // constructed to `nullptr`s.
   }
 
   /**
    * @brief Constructor for nullptr (creates a disengaged optional)
    */
   constexpr optional_ptr(std::nullptr_t) noexcept
-    : m_raw_ptrs({ nullptr, nullptr })
   {
   }
 

--- a/v4/include/libhal/pointers.hpp
+++ b/v4/include/libhal/pointers.hpp
@@ -1047,16 +1047,12 @@ public:
   /**
    * @brief Default constructor creates a disengaged optional
    */
-  constexpr optional_ptr() noexcept
-  {
-  }
+  constexpr optional_ptr() noexcept = default;
 
   /**
    * @brief Constructor for nullptr (creates a disengaged optional)
    */
-  constexpr optional_ptr(std::nullptr_t) noexcept
-  {
-  }
+  constexpr optional_ptr(std::nullptr_t) noexcept = default;
 
   /**
    * @brief Move constructor is deleted


### PR DESCRIPTION
This includes the rebase needed to merge the change.