### PR TITLE
:sparkles: (minor) USB: Add low power mode support, add host event APIs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:24.04
 
-# NOTE: Some Conan Center packages implicitly depend on system-installed 
-# toolchain tools (CMake, LLVM, GCC, etc.) rather than declaring them as 
-# tool requirements. The following packages are installed to satisfy 
+# NOTE: Some Conan Center packages implicitly depend on system-installed
+# toolchain tools (CMake, LLVM, GCC, etc.) rather than declaring them as
+# tool requirements. The following packages are installed to satisfy
 # these implicit dependencies.
 
 RUN apt update --fix-missing && apt upgrade -y

--- a/v4/include/libhal/usb.hpp
+++ b/v4/include/libhal/usb.hpp
@@ -75,6 +75,103 @@ struct endpoint_info
 };
 
 /**
+ * @brief USB bus-level events forwarded to @ref interface implementations.
+ *
+ * This is the subset of @ref host_event that is relevant to interface
+ * drivers. The enumerator translates @ref host_event values and forwards
+ * the appropriate host_event to all active interfaces via
+ * @ref interface::on_host_event.
+ *
+ * Interface implementations use these events to manage their own state,
+ * such as enabling or disabling hardware, stopping or resuming data
+ * queuing, or resetting internal transfer state.
+ */
+enum class host_event : hal::u8
+{
+
+  /// @brief The host has driven SE0 for >10ms, triggering re-enumeration,
+  ///        or the application has called @ref control_endpoint::connect
+  ///        to force a reconnect.
+  ///
+  /// All endpoint state has been cleared by hardware. Interfaces should
+  /// discard any pending transfer state and reset internal state machines.
+  /// The enumerator will re-run the full enumeration sequence and deliver
+  /// @ref enumerated again when complete.
+  reset,
+
+  /// @brief A SETUP packet is available in the control endpoint buffer.
+  ///
+  /// The enumerator should call @ref control_endpoint::read to retrieve
+  /// the 8-byte setup packet and process the request.
+  setup_packet,
+
+  /// @brief A data OUT packet is available in the control endpoint buffer.
+  ///
+  /// Delivered during the data phase of a host-to-device control transfer,
+  /// after a setup packet with wLength > 0 has been processed. The
+  /// enumerator or active interface should call @ref control_endpoint::read
+  /// to retrieve the data.
+  data_packet,
+
+  /// @brief Enumeration is complete. The host has issued SET_CONFIGURATION
+  ///        and the device is now fully operational.
+  ///
+  /// Interfaces should begin normal operation and may start queuing data
+  /// to their endpoints. Devices start in a suspended state and must
+  /// wait for this event before transmitting.
+  enumerated,
+
+  /// @brief The bus has resumed from any sleep or suspend state.
+  ///
+  /// Covers exit from L1, L2, U1, U2, and U3. Interfaces may resume
+  /// normal endpoint operation. Any endpoint writes that were blocked
+  /// during suspend will now complete.
+  resume,
+
+  /// @brief The host has suspended the bus and has granted the device
+  ///        permission to initiate remote wakeup (L2/U3).
+  ///
+  /// Interfaces should monitor for new data. When new data arrives,
+  /// calling write() on an endpoint will automatically assert resume
+  /// signaling to wake the host before completing the transfer.
+  ///
+  /// The device must reduce bus current draw to <= 2.5mA within 7ms.
+  suspend_with_wakeup,
+
+  /// @brief The host has suspended the bus without granting remote wakeup
+  ///        permission (L2/U3).
+  ///
+  /// Interfaces should cease all activity and queue no data to endpoints.
+  /// Any endpoint writes attempted while in this state will block
+  /// indefinitely until the host resumes the bus on its own.
+  ///
+  /// The device must reduce bus current draw to <= 2.5mA within 7ms.
+  suspend_without_wakeup,
+
+  /// @brief The host has requested a fast sleep (L1/LPM) transition.
+  ///
+  /// Exit latency is in the range of microseconds. There are no strict
+  /// power draw requirements in this state. Interfaces may choose to
+  /// remain operational or reduce activity. The endpoint write path will
+  /// automatically handle resume signaling if remote wakeup is enabled.
+  ///
+  /// Only fired on hardware with USB 2.0 LPM support.
+  sleep,
+
+  /// @brief The USB 3.0+ link has entered U1 standby.
+  ///
+  /// Very fast exit (~microseconds). Hardware-managed transition.
+  /// Interfaces typically need not respond to this event.
+  u1_sleep,
+
+  /// @brief The USB 3.0+ link has entered U2 standby.
+  ///
+  /// Fast exit (~milliseconds). Hardware-managed transition.
+  /// Interfaces may optionally reduce activity in response.
+  u2_sleep,
+};
+
+/**
  * @brief Generic usb endpoint interface
  *
  * This interface exists to mandate specific generic APIs for all usb endpoints.
@@ -264,6 +361,9 @@ public:
    * @brief Returns whether the endpoint's receive buffer contains a setup
    * packet.
    *
+   * @deprecated Use on_host_event and the host_event type to detect if a setup
+   * command has arrived.
+   *
    * Returns `true` until all 8 bytes of the setup packet have been extracted
    * via `read()`. Returns `false` once the setup packet has been fully consumed
    * or if the last received packet was not a setup packet.
@@ -280,9 +380,109 @@ public:
    * @return `true` if the receive buffer contains an unconsumed setup packet.
    * @return `false` otherwise.
    */
-  [[nodiscard]] std::optional<bool> has_setup() const noexcept
+  [[deprecated("This API is deprecated in favor of on_host_event() with "
+               "callback. To determine if the event means there is a new setup "
+               "packet, check the host_event and see if it equals "
+               "host_event::setup_packet.")]] [[nodiscard]] std::optional<bool>
+  has_setup() const noexcept
   {
     return driver_has_setup();
+  }
+
+  /**
+   * @brief Register a callback for control endpoint and bus-level events.
+   *
+   * The registered callback is invoked from interrupt context when any
+   * @ref host_event occurs. The callback must not perform any blocking
+   * operations.
+   *
+   * Replaces the @ref on_receive callbacks. Only one callback may be registered
+   * at a time. Calling this function again replaces the previously registered
+   * callback.
+   *
+   * The enumerator registers this callback internally. Applications should
+   * not call this directly.
+   *
+   * This API does nothing if not implemented
+   *
+   * @param p_callback - callback to invoke when an event occurs, receives
+   *                     the @ref host_event indicating which event fired.
+   * @throws hal::operation_not_supported - if not implemented by driver
+   */
+  void on_host_event(hal::callback<void(host_event)> const& p_callback)
+  {
+    driver_on_host_event(p_callback);
+  }
+
+  /**
+   * @brief Grant or revoke the device's permission to initiate remote wakeup.
+   *
+   * Called by the enumerator in response to SET_FEATURE(DEVICE_REMOTE_WAKEUP)
+   * and CLEAR_FEATURE(DEVICE_REMOTE_WAKEUP) setup packets from the host.
+   *
+   * When enabled, IN endpoint writes issued while the bus is suspended will
+   * automatically assert resume signaling before completing the transfer,
+   * waking the host if it is suspended.
+   *
+   * When disabled, IN endpoint writes while suspended will block until the
+   * host resumes the bus on its own.
+   *
+   * This API does nothing if not implemented
+   *
+   * @param p_enabled - true if the host has granted remote wakeup permission,
+   *                    false if the host has revoked it.
+   */
+  void set_remote_wakeup_enabled(bool p_enabled)
+  {
+    return driver_set_remote_wakeup_enabled(p_enabled);
+  }
+
+  /**
+   * @brief Accept or reject an incoming L1 LPM sleep request from the host.
+   *
+   * Called by the enumerator when an LPM token is received from the host
+   * requesting the device enter the L1 (sleep) power state. The implementation
+   * must respond to the host by either acknowledging or rejecting the
+   * transition.
+   *
+   * Accepting the request causes the hardware to enter L1 sleep, after which
+   * the enumerator dispatches `host_event::sleep` to all registered interfaces.
+   * Rejecting the request keeps the device in L0 (active) state and no event
+   * is dispatched.
+   *
+   * This function is invoked exclusively by the enumerator and must not be
+   * called directly by interface implementors or application code.
+   *
+   * This API does nothing if not implemented
+   *
+   * @param p_accept `true` to acknowledge the L1 sleep request and allow the
+   *   device to enter L1; `false` to reject it and remain in L0.
+   */
+  void acknowledge_sleep(bool p_accept)
+  {
+    return driver_acknowledge_sleep(p_accept);
+  }
+
+  /**
+   * @brief Query whether the hardware supports USB 2.0 L1 Link Power
+   * Management.
+   *
+   * The enumerator calls this during enumeration to determine whether to
+   * include a Binary Object Store (BOS) descriptor advertising LPM capability.
+   * If this returns `false`, the BOS descriptor is omitted and the host will
+   * never issue LPM tokens, meaning `acknowledge_sleep()` will never be called.
+   *
+   * Implementations should return a compile-time or hardware-register-derived
+   * constant. The result must remain stable for the lifetime of the
+   * `control_endpoint` object.
+   *
+   * @return `true` if the hardware supports L1 LPM and the enumerator should
+   *   advertise BOS/LPM capability to the host; `false` otherwise. If not
+   *   implemented by driver, then defaults to return false.
+   */
+  [[nodiscard]] bool supports_lpm()
+  {
+    return driver_supports_lpm();
   }
 
 private:
@@ -295,6 +495,19 @@ private:
   [[nodiscard]] virtual std::optional<bool> driver_has_setup() const noexcept
   {
     return {};
+  }
+  virtual void driver_on_host_event(callback<void(host_event)> const&)
+  {
+  }
+  virtual void driver_set_remote_wakeup_enabled(bool)
+  {
+  }
+  virtual void driver_acknowledge_sleep(bool)
+  {
+  }
+  virtual bool driver_supports_lpm()
+  {
+    return false;
   }
 };
 
@@ -324,6 +537,8 @@ public:
    *
    * @param p_data - a scatter span of bytes to be written to the endpoint
    * memory and sent over USB.
+   * @throws hal::operation_not_permitted - if the USB is suspended and a write
+   * is attempted.
    */
   void write(scatter_span<byte const> p_data)
   {
@@ -1052,6 +1267,60 @@ public:
   {
     return driver_handle_request(p_setup, p_endpoint);
   }
+  /**
+   * @brief Respond to bus-level host events dispatched by the enumerator.
+   *
+   * Called by the enumerator after it has processed a @ref host_event and
+   * updated its own state. Implementations that need to react to power
+   * transitions, suspend/resume, or bus reset should override this method.
+   *
+   * `host_event::setup_packet` and `host_event::data_packet` are consumed
+   * internally by the enumerator and are never forwarded here.
+   *
+   * This method is called from the enumerator's main context, not from
+   * interrupt context.
+   *
+   * **Event-specific guidance:**
+   *
+   * - @ref host_event::reset — Discard all pending transfer state. The
+   *   enumerator will re-run enumeration and re-initialize all descriptors
+   *   before normal operation resumes.
+   *
+   * - @ref host_event::enumerated — The device has completed enumeration and
+   *   is ready for normal operation. Interfaces may begin queuing data to
+   *   their endpoints.
+   *
+   * - @ref host_event::sleep — The host has granted an L1 LPM sleep request.
+   *   Cease queuing data to endpoints. Any pending IN writes will block until
+   *   the bus resumes.
+   *
+   * - @ref host_event::u1_sleep / @ref host_event::u2_sleep — USB 3.0+ U1/U2
+   *   link power states entered. Behavior mirrors `sleep` for interface
+   *   purposes.
+   *
+   * - @ref host_event::suspend_with_wakeup — The bus has entered L2/U3
+   *   suspend and the host has granted remote wakeup capability. The interface
+   *   may trigger a wakeup by writing to any IN endpoint; the endpoint driver
+   *   handles remote wakeup signaling internally.
+   *
+   * - @ref host_event::suspend_without_wakeup — The bus has entered L2/U3
+   *   suspend without remote wakeup capability. The interface must not attempt
+   *   to initiate wakeup. Any IN endpoint write attempted during this state
+   *   will throw hal::operation_not_permitted, as the device has no means to
+   *   deliver data or signal the host to resume.
+   *
+   * - @ref host_event::resume — The bus has returned to L0/U0 active state
+   *   from any sleep or suspend condition. Normal endpoint operation may
+   *   resume.
+   *
+   * The default implementation is a no-op.
+   *
+   * @param p_event The host event that occurred.
+   */
+  void handle_host_event(host_event p_event)
+  {
+    return driver_handle_host_event(p_event);
+  }
 
   virtual ~interface() = default;
 
@@ -1063,6 +1332,9 @@ private:
                                               endpoint_io& p_endpoint) = 0;
   virtual bool driver_handle_request(setup_packet const& p_setup,
                                      endpoint_io& p_endpoint) = 0;
+  virtual void driver_handle_host_event(host_event)
+  {
+  }
 };
 }  // namespace hal::v5::usb
 

--- a/v4/include/libhal/usb.hpp
+++ b/v4/include/libhal/usb.hpp
@@ -21,6 +21,7 @@
 #include <span>
 
 #include "functional.hpp"
+#include "libhal/error.hpp"
 #include "scatter_span.hpp"
 #include "units.hpp"
 
@@ -250,6 +251,144 @@ private:
 };
 
 /**
+ * @brief Bitmask descriptor of USB Link Power Management (LPM) states
+ *        supported by a device or host.
+ *
+ * USB LPM allows the host and device to negotiate low-power states during
+ * periods of inactivity without requiring a full disconnect/reconnect cycle.
+ * USB 2.0 LPM defines the L1 sleep state; USB 3.x SuperSpeed defines the
+ * U1 and U2 link states.
+ *
+ * Use the setter overloads (which return `*this`) to build a value with
+ * method chaining:
+ *
+ * @code
+ * lpm_support capabilities{};
+ * capabilities.l1_supported(true).u1_supported(true);
+ * @endcode
+ */
+struct lpm_support
+{
+  /// @brief Bitmask for the USB 2.0 L1 (sleep) LPM state.
+  static constexpr hal::u8 l1_mask = 1 << 0;
+
+  /// @brief Bitmask for the USB 3.x U1 link state.
+  static constexpr hal::u8 u1_mask = 1 << 1;
+
+  /// @brief Bitmask for the USB 3.x U2 link state.
+  static constexpr hal::u8 u2_mask = 1 << 2;
+
+  /**
+   * @brief Returns whether the USB 2.0 L1 sleep state is supported.
+   *
+   * @return true - L1 LPM is supported
+   * @return false - L1 LPM is not supported
+   */
+  [[nodiscard]] constexpr bool l1_supported() const noexcept
+  {
+    return bits & l1_mask;
+  }
+
+  /**
+   * @brief Returns whether the USB 3.x U1 link state is supported.
+   *
+   * @return true - U1 is supported
+   * @return false - U1 is not supported
+   */
+  [[nodiscard]] constexpr bool u1_supported() const noexcept
+  {
+    return bits & u1_mask;
+  }
+
+  /**
+   * @brief Returns whether the USB 3.x U2 link state is supported.
+   *
+   * @return true - U2 is supported
+   * @return false - U2 is not supported
+   */
+  [[nodiscard]] constexpr bool u2_supported() const noexcept
+  {
+    return bits & u2_mask;
+  }
+
+  /**
+   * @brief Enables or disables L1 support in the bitmask.
+   *
+   * @param p_enable - true to mark L1 as supported, false to clear it
+   * @return lpm_support& - reference to this object for method chaining
+   */
+  constexpr lpm_support& l1_supported(bool p_enable) noexcept
+  {
+    set(l1_mask, p_enable);
+    return *this;
+  }
+
+  /**
+   * @brief Enables or disables U1 support in the bitmask.
+   *
+   * @param p_enable - true to mark U1 as supported, false to clear it
+   * @return lpm_support& - reference to this object for method chaining
+   */
+  constexpr lpm_support& u1_supported(bool p_enable) noexcept
+  {
+    set(u1_mask, p_enable);
+    return *this;
+  }
+
+  /**
+   * @brief Enables or disables U2 support in the bitmask.
+   *
+   * @param p_enable - true to mark U2 as supported, false to clear it
+   * @return lpm_support& - reference to this object for method chaining
+   */
+  constexpr lpm_support& u2_supported(bool p_enable) noexcept
+  {
+    set(u2_mask, p_enable);
+    return *this;
+  }
+
+  /**
+   * @brief Returns whether any LPM state is supported.
+   *
+   * @return true - at least one LPM state bit is set
+   * @return false - no LPM states are supported
+   */
+  [[nodiscard]] constexpr bool any() const noexcept
+  {
+    return bits != 0;
+  }
+
+  /**
+   * @brief Returns whether no LPM states are supported.
+   *
+   * @return true - no LPM state bits are set
+   * @return false - at least one LPM state is supported
+   */
+  [[nodiscard]] constexpr bool none() const noexcept
+  {
+    return bits == 0;
+  }
+
+  /**
+   * @brief Sets or clears a single LPM state bit.
+   *
+   * @param p_mask - bitmask of the state to modify (e.g. `l1_mask`)
+   * @param p_enable - true to set the bit, false to clear it
+   */
+  constexpr void set(hal::u8 p_mask, bool p_enable) noexcept
+  {
+    if (p_enable) {
+      bits |= p_mask;
+    } else {
+      bits &= ~p_mask;
+    }
+  }
+
+  /// @brief Raw bitmask of supported LPM states; zero means none supported.
+  hal::u8 bits = 0;
+};
+
+/**
  * @brief USB Control Endpoint Interface
  *
  * This class represents the control endpoint of a USB device. The control
@@ -464,23 +603,24 @@ public:
   }
 
   /**
-   * @brief Query whether the hardware supports USB 2.0 L1 Link Power
-   * Management.
+   * @brief Query which USB Link Power Management states the hardware supports.
    *
-   * The enumerator calls this during enumeration to determine whether to
-   * include a Binary Object Store (BOS) descriptor advertising LPM capability.
-   * If this returns `false`, the BOS descriptor is omitted and the host will
-   * never issue LPM tokens, meaning `acknowledge_sleep()` will never be called.
+   * The enumerator calls this during enumeration to determine which LPM
+   * capability descriptors to include. For USB 2.0, a Binary Object Store
+   * (BOS) descriptor advertising L1 support is included only when
+   * `lpm_support::l1_supported()` is true. For USB 3.x, U1/U2 capability
+   * descriptors follow the same pattern. If no bits are set the relevant
+   * descriptors are omitted and the host will never enter those link states,
+   * meaning `acknowledge_sleep()` will never be called.
    *
    * Implementations should return a compile-time or hardware-register-derived
    * constant. The result must remain stable for the lifetime of the
    * `control_endpoint` object.
    *
-   * @return `true` if the hardware supports L1 LPM and the enumerator should
-   *   advertise BOS/LPM capability to the host; `false` otherwise. If not
-   *   implemented by driver, then defaults to return false.
+   * @return lpm_support - bitmask of supported LPM states; defaults to an
+   *   all-zero value (no LPM support) if not overridden by the driver.
    */
-  [[nodiscard]] bool supports_lpm()
+  [[nodiscard]] lpm_support supports_lpm()
   {
     return driver_supports_lpm();
   }
@@ -505,9 +645,9 @@ private:
   virtual void driver_acknowledge_sleep(bool)
   {
   }
-  virtual bool driver_supports_lpm()
+  virtual lpm_support driver_supports_lpm()
   {
-    return false;
+    return {};
   }
 };
 

--- a/v4/include/libhal/usb.hpp
+++ b/v4/include/libhal/usb.hpp
@@ -21,7 +21,6 @@
 #include <span>
 
 #include "functional.hpp"
-#include "libhal/error.hpp"
 #include "scatter_span.hpp"
 #include "units.hpp"
 
@@ -76,12 +75,12 @@ struct endpoint_info
 };
 
 /**
- * @brief USB bus-level events forwarded to @ref interface implementations.
+ * @brief USB host-level events forwarded to @ref interface implementations from
+ * the enumerator.
  *
- * This is the subset of @ref host_event that is relevant to interface
- * drivers. The enumerator translates @ref host_event values and forwards
- * the appropriate host_event to all active interfaces via
- * @ref interface::on_host_event.
+ * The enumerator calls @ref interface::handle_host_event on all usb interfaces
+ * it has control over based on bus events and setup packets received from the
+ * host.
  *
  * Interface implementations use these events to manage their own state,
  * such as enabling or disabling hardware, stopping or resuming data
@@ -89,7 +88,6 @@ struct endpoint_info
  */
 enum class host_event : hal::u8
 {
-
   /// @brief The host has driven SE0 for >10ms, triggering re-enumeration,
   ///        or the application has called @ref control_endpoint::connect
   ///        to force a reconnect.
@@ -99,20 +97,6 @@ enum class host_event : hal::u8
   /// The enumerator will re-run the full enumeration sequence and deliver
   /// @ref enumerated again when complete.
   reset,
-
-  /// @brief A SETUP packet is available in the control endpoint buffer.
-  ///
-  /// The enumerator should call @ref control_endpoint::read to retrieve
-  /// the 8-byte setup packet and process the request.
-  setup_packet,
-
-  /// @brief A data OUT packet is available in the control endpoint buffer.
-  ///
-  /// Delivered during the data phase of a host-to-device control transfer,
-  /// after a setup packet with wLength > 0 has been processed. The
-  /// enumerator or active interface should call @ref control_endpoint::read
-  /// to retrieve the data.
-  data_packet,
 
   /// @brief Enumeration is complete. The host has issued SET_CONFIGURATION
   ///        and the device is now fully operational.
@@ -169,6 +153,80 @@ enum class host_event : hal::u8
   ///
   /// Fast exit (~milliseconds). Hardware-managed transition.
   /// Interfaces may optionally reduce activity in response.
+  u2_sleep,
+};
+
+/**
+ * @brief Raw USB bus-level events reported by hardware drivers to the
+ *        enumerator.
+ *
+ * This is the hardware-visible set of bus activity. Drivers report these
+ * events via the @ref control_endpoint::on_bus_event callback. The enumerator
+ * consumes them, updates its own protocol state (enumeration, remote wakeup
+ * permission, etc.), and translates them into the richer @ref host_event
+ * vocabulary before forwarding to interface implementations.
+ */
+enum class bus_event : hal::u8
+{
+  /// @brief The host has driven SE0 for >2.5ms, or the application has
+  ///        called @ref control_endpoint::connect to force a reconnect.
+  ///
+  /// All endpoint state has been cleared by hardware. The enumerator will
+  /// discard pending transfer state, reset its internal state machine, and
+  /// re-run the full enumeration sequence. Remote wakeup permission is
+  /// implicitly revoked on reset and must be re-granted by the host via
+  /// SET_FEATURE(DEVICE_REMOTE_WAKEUP) during the new enumeration.
+  reset,
+
+  /// @brief A SETUP packet is available in the control endpoint buffer.
+  ///
+  /// The enumerator should call @ref control_endpoint::read to retrieve
+  /// the 8-byte setup packet and process the request.
+  setup_packet,
+
+  /// @brief A data OUT packet is available in the control endpoint buffer.
+  ///
+  /// Delivered during the data phase of a host-to-device control transfer,
+  /// after a setup packet with wLength > 0 has been processed. The
+  /// enumerator should call @ref control_endpoint::read to retrieve the
+  /// data and complete the pending request.
+  data_packet,
+
+  /// @brief The bus has resumed from any suspend or sleep state.
+  ///
+  /// Covers exit from L1, L2, U1, U2, and U3. The enumerator forwards this
+  /// as @ref host_event::resume to all active interfaces.
+  resume,
+
+  /// @brief The host has suspended the bus (L2/U3).
+  ///
+  /// SOF packets have been absent for >= 3ms. The hardware cannot determine
+  /// whether remote wakeup was granted; the enumerator resolves this from
+  /// its tracked SET_FEATURE / CLEAR_FEATURE state and forwards either
+  /// @ref host_event::suspend_with_wakeup or
+  /// @ref host_event::suspend_without_wakeup to interfaces.
+  ///
+  /// The device must reduce bus current draw to <= 2.5mA within 7ms.
+  suspend,
+
+  /// @brief The host has requested a fast sleep (L1/LPM) transition.
+  ///
+  /// Exit latency is in the range of microseconds. The enumerator forwards
+  /// this as @ref host_event::sleep to all active interfaces.
+  ///
+  /// Only fired on hardware with USB 2.0 LPM support.
+  sleep,
+
+  /// @brief The USB 3.0+ link has entered U1 standby.
+  ///
+  /// Very fast exit (~microseconds). Hardware-managed transition. The
+  /// enumerator forwards this as @ref host_event::u1_sleep to interfaces.
+  u1_sleep,
+
+  /// @brief The USB 3.0+ link has entered U2 standby.
+  ///
+  /// Fast exit (~milliseconds). Hardware-managed transition. The enumerator
+  /// forwards this as @ref host_event::u2_sleep to interfaces.
   u2_sleep,
 };
 
@@ -264,19 +322,35 @@ private:
  *
  * @code
  * lpm_support capabilities{};
- * capabilities.l1_supported(true).u1_supported(true);
+ * capabilities.remote_wakeup_supported(true)
+ *             .l1_supported(true)
+ *             .u1_supported(true);
  * @endcode
  */
 struct lpm_support
 {
+  /// @brief Bitmask for USB 2.0 remote wakeup capability.
+  static constexpr hal::u8 remote_wakeup_mask = 1 << 0;
+
   /// @brief Bitmask for the USB 2.0 L1 (sleep) LPM state.
-  static constexpr hal::u8 l1_mask = 1 << 0;
+  static constexpr hal::u8 l1_mask = 1 << 1;
 
   /// @brief Bitmask for the USB 3.x U1 link state.
-  static constexpr hal::u8 u1_mask = 1 << 1;
+  static constexpr hal::u8 u1_mask = 1 << 2;
 
   /// @brief Bitmask for the USB 3.x U2 link state.
-  static constexpr hal::u8 u2_mask = 1 << 2;
+  static constexpr hal::u8 u2_mask = 1 << 3;
+
+  /**
+   * @brief Returns whether USB 2.0 remote wakeup is supported.
+   *
+   * @return true - remote wakeup is supported
+   * @return false - remote wakeup is not supported
+   */
+  [[nodiscard]] constexpr bool remote_wakeup_supported() const noexcept
+  {
+    return bits & remote_wakeup_mask;
+  }
 
   /**
    * @brief Returns whether the USB 2.0 L1 sleep state is supported.
@@ -309,6 +383,19 @@ struct lpm_support
   [[nodiscard]] constexpr bool u2_supported() const noexcept
   {
     return bits & u2_mask;
+  }
+
+  /**
+   * @brief Enables or disables remote wakeup support in the bitmask.
+   *
+   * @param p_enable - true to mark remote wakeup as supported, false to clear
+   * it
+   * @return lpm_support& - reference to this object for method chaining
+   */
+  constexpr lpm_support& remote_wakeup_supported(bool p_enable) noexcept
+  {
+    set(remote_wakeup_mask, p_enable);
+    return *this;
   }
 
   /**
@@ -383,6 +470,8 @@ struct lpm_support
       bits &= ~p_mask;
     }
   }
+
+  constexpr bool operator<=>(lpm_support const& rhs) const = default;
 
   /// @brief Raw bitmask of supported LPM states; zero means none supported.
   hal::u8 bits = 0;
@@ -500,7 +589,7 @@ public:
    * @brief Returns whether the endpoint's receive buffer contains a setup
    * packet.
    *
-   * @deprecated Use on_host_event and the host_event type to detect if a setup
+   * @deprecated Use on_bus_event and the bus_event type to detect if a setup
    * command has arrived.
    *
    * Returns `true` until all 8 bytes of the setup packet have been extracted
@@ -519,10 +608,10 @@ public:
    * @return `true` if the receive buffer contains an unconsumed setup packet.
    * @return `false` otherwise.
    */
-  [[deprecated("This API is deprecated in favor of on_host_event() with "
+  [[deprecated("This API is deprecated in favor of on_bus_event() with "
                "callback. To determine if the event means there is a new setup "
-               "packet, check the host_event and see if it equals "
-               "host_event::setup_packet.")]] [[nodiscard]] std::optional<bool>
+               "packet, check the bus_event and see if it equals "
+               "bus_event::setup_packet.")]] [[nodiscard]] std::optional<bool>
   has_setup() const noexcept
   {
     return driver_has_setup();
@@ -532,25 +621,28 @@ public:
    * @brief Register a callback for control endpoint and bus-level events.
    *
    * The registered callback is invoked from interrupt context when any
-   * @ref host_event occurs. The callback must not perform any blocking
+   * @ref bus_event occurs. The callback must not perform any blocking
    * operations.
    *
-   * Replaces the @ref on_receive callbacks. Only one callback may be registered
-   * at a time. Calling this function again replaces the previously registered
-   * callback.
+   * Replaces the @ref on_receive callbacks. If a previously set `on_receive`
+   * callback was set, calling this
+   * function may remove the previous `on_receive` callback and replace it with
+   * the `on_bus_event` callback.
+   *
+   * Only one callback may be registered at a time. Calling this function again
+   * replaces the previously registered callback.
    *
    * The enumerator registers this callback internally. Applications should
    * not call this directly.
    *
-   * This API does nothing if not implemented
+   * This API does nothing if not implemented.
    *
    * @param p_callback - callback to invoke when an event occurs, receives
-   *                     the @ref host_event indicating which event fired.
-   * @throws hal::operation_not_supported - if not implemented by driver
+   *                     the @ref bus_event indicating which event fired.
    */
-  void on_host_event(hal::callback<void(host_event)> const& p_callback)
+  void on_bus_event(hal::callback<void(bus_event)> const& p_callback)
   {
-    driver_on_host_event(p_callback);
+    driver_on_bus_event(p_callback);
   }
 
   /**
@@ -566,14 +658,31 @@ public:
    * When disabled, IN endpoint writes while suspended will block until the
    * host resumes the bus on its own.
    *
-   * This API does nothing if not implemented
+   * This API does nothing if not implemented.
    *
    * @param p_enabled - true if the host has granted remote wakeup permission,
    *                    false if the host has revoked it.
    */
-  void set_remote_wakeup_enabled(bool p_enabled)
+  void remote_wakeup_enable(bool p_enabled)
   {
-    return driver_set_remote_wakeup_enabled(p_enabled);
+    return driver_remote_wakeup_enable(p_enabled);
+  }
+
+  /**
+   * @brief Query whether the host has granted remote wakeup permission.
+   *
+   * Returns the current remote wakeup grant state as last set by the enumerator
+   * via @ref remote_wakeup_enable. Returns `false` by default if not overridden
+   * by the driver.
+   *
+   * @return true - the host has granted remote wakeup permission
+   * @return false - remote wakeup permission has not been granted, was
+   * revoked, or the hardware isn't capable of performing a wake K-state on the
+   * bus.
+   */
+  [[nodiscard]] bool remote_wakeup_granted()
+  {
+    return driver_remote_wakeup_granted();
   }
 
   /**
@@ -585,7 +694,7 @@ public:
    * transition.
    *
    * Accepting the request causes the hardware to enter L1 sleep, after which
-   * the enumerator dispatches `host_event::sleep` to all registered interfaces.
+   * the enumerator dispatches `bus_event::sleep` to all registered interfaces.
    * Rejecting the request keeps the device in L0 (active) state and no event
    * is dispatched.
    *
@@ -594,8 +703,8 @@ public:
    *
    * This API does nothing if not implemented
    *
-   * @param p_accept `true` to acknowledge the L1 sleep request and allow the
-   *   device to enter L1; `false` to reject it and remain in L0.
+   * @param p_accept - `true` to acknowledge the L1 sleep request and allow the
+   *                 device to enter L1; `false` to reject it and remain in L0.
    */
   void acknowledge_sleep(bool p_accept)
   {
@@ -636,11 +745,15 @@ private:
   {
     return {};
   }
-  virtual void driver_on_host_event(callback<void(host_event)> const&)
+  virtual void driver_on_bus_event(callback<void(bus_event)> const&)
   {
   }
-  virtual void driver_set_remote_wakeup_enabled(bool)
+  virtual void driver_remote_wakeup_enable(bool)
   {
+  }
+  virtual bool driver_remote_wakeup_granted()
+  {
+    return false;
   }
   virtual void driver_acknowledge_sleep(bool)
   {
@@ -1426,17 +1539,9 @@ public:
    *   enumerator will re-run enumeration and re-initialize all descriptors
    *   before normal operation resumes.
    *
-   * - @ref host_event::enumerated — The device has completed enumeration and
-   *   is ready for normal operation. Interfaces may begin queuing data to
+   * - @ref host_event::enumerated — The enumerator has completed enumeration
+   *   and is ready for normal operation. Interfaces may begin queuing data to
    *   their endpoints.
-   *
-   * - @ref host_event::sleep — The host has granted an L1 LPM sleep request.
-   *   Cease queuing data to endpoints. Any pending IN writes will block until
-   *   the bus resumes.
-   *
-   * - @ref host_event::u1_sleep / @ref host_event::u2_sleep — USB 3.0+ U1/U2
-   *   link power states entered. Behavior mirrors `sleep` for interface
-   *   purposes.
    *
    * - @ref host_event::suspend_with_wakeup — The bus has entered L2/U3
    *   suspend and the host has granted remote wakeup capability. The interface
@@ -1452,6 +1557,14 @@ public:
    * - @ref host_event::resume — The bus has returned to L0/U0 active state
    *   from any sleep or suspend condition. Normal endpoint operation may
    *   resume.
+   *
+   * - @ref host_event::sleep — The host has granted an L1 LPM sleep request.
+   *   Cease queuing data to endpoints. Any pending IN writes will block until
+   *   the bus resumes.
+   *
+   * - @ref host_event::u1_sleep / @ref host_event::u2_sleep — USB 3.0+ U1/U2
+   *   link power states entered. Behavior mirrors `sleep` for interface
+   *   purposes.
    *
    * The default implementation is a no-op.
    *
@@ -1484,15 +1597,14 @@ using v5::usb::bulk_out_endpoint;
 using v5::usb::control_endpoint;
 using v5::usb::endpoint;
 using v5::usb::endpoint_info;
+using v5::usb::endpoint_io;
 using v5::usb::in_endpoint;
 using v5::usb::in_endpoint_type;
+using v5::usb::interface;
 using v5::usb::interrupt_in_endpoint;
 using v5::usb::interrupt_out_endpoint;
 using v5::usb::out_endpoint;
 using v5::usb::out_endpoint_type;
-
-using v5::usb::endpoint_io;
-using v5::usb::interface;
 using v5::usb::setup_packet;
 using v5::usb::standard_request_types;
 }  // namespace hal::usb

--- a/v4/include/libhal/usb.hpp
+++ b/v4/include/libhal/usb.hpp
@@ -577,6 +577,11 @@ public:
   /**
    * @brief Set a callback function for when USB requests are received
    *
+   * @deprecated Use @ref on_bus_event instead. That API provides the full set
+   * of bus-level events (reset, setup packet, data packet, suspend, resume,
+   * sleep) in a single callback, superseding this one. Calling @ref
+   * on_bus_event may clear any previously registered `on_receive` callback.
+   *
    * @param p_callback The callback function to be called when a USB request
    * command is received on the control endpoint.
    */
@@ -1207,10 +1212,10 @@ struct setup_packet
   @tparam offset - The offset into the setup packet array (Array after the
   offset needs to be at least two bytes)
 
-  @param n - 16-bit value to emplace
+  @param p_value - 16-bit value to emplace
    */
   template<usize offset>
-  constexpr void set_le_u16(u16 n)
+  constexpr void set_le_u16(u16 p_value)
   {
     static_assert(offset < 7,
                   "Offset greater than size of setup bytes, need at least two "
@@ -1218,8 +1223,9 @@ struct setup_packet
     static_assert(0 == (offset & 0b1),
                   "Offset must be even number (2-byte/16-bit aligned)");
 
-    raw_request_bytes[offset + 0] = static_cast<hal::byte>(n & 0xFF);
-    raw_request_bytes[offset + 1] = static_cast<hal::byte>((n >> 8) & 0xFF);
+    raw_request_bytes[offset + 0] = static_cast<hal::byte>(p_value & 0xFF);
+    raw_request_bytes[offset + 1] =
+      static_cast<hal::byte>((p_value >> 8) & 0xFF);
   }
 
   /**
@@ -1229,13 +1235,13 @@ struct setup_packet
    * value in host byte order. Used internally for parsing multi-byte fields
    * from raw USB data.
    *
-   * @param first Low byte (least significant)
-   * @param second High byte (most significant)
+   * @param p_first Low byte (least significant)
+   * @param p_second High byte (most significant)
    * @return u16 Combined 16-bit value in host byte order
    */
-  constexpr static u16 from_le_bytes(hal::byte first, hal::byte second)
+  constexpr static u16 from_le_bytes(hal::byte p_first, hal::byte p_second)
   {
-    return static_cast<u16>(second) << 8 | first;
+    return static_cast<u16>(p_second) << 8 | p_first;
   }
 
   /**
@@ -1244,14 +1250,14 @@ struct setup_packet
    * Helper function to convert a 16-bit value into two bytes in little-endian
    * format. Used when constructing USB descriptor data or response packets.
    *
-   * @param n 16-bit value to convert
+   * @param p_value 16-bit value to convert
    * @return std::array<hal::byte, 2> Array with low byte first, high byte
    * second
    */
-  [[nodiscard]] constexpr static std::array<hal::byte, 2> to_le_u16(u16 n)
+  [[nodiscard]] constexpr static std::array<hal::byte, 2> to_le_u16(u16 p_value)
   {
-    return { static_cast<hal::byte>(n & 0xFF),
-             static_cast<hal::byte>((n >> 8) & 0xFF) };
+    return { static_cast<hal::byte>(p_value & 0xFF),
+             static_cast<hal::byte>((p_value >> 8) & 0xFF) };
   }
 
   std::array<byte, 8> raw_request_bytes;

--- a/v4/tests/usb.test.cpp
+++ b/v4/tests/usb.test.cpp
@@ -21,6 +21,21 @@
 
 #include <boost/ut.hpp>
 
+#if defined(__clang__)
+#define SUPPRESS_DEPRECATED_START                                              \
+  _Pragma("clang diagnostic push")                                             \
+    _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
+#define SUPPRESS_DEPRECATED_END _Pragma("clang diagnostic pop")
+#elif defined(__GNUC__)
+#define SUPPRESS_DEPRECATED_START                                              \
+  _Pragma("GCC diagnostic push")                                               \
+    _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#define SUPPRESS_DEPRECATED_END _Pragma("GCC diagnostic pop")
+#else
+#define SUPPRESS_DEPRECATED_START
+#define SUPPRESS_DEPRECATED_END
+#endif
+
 namespace hal::usb {
 
 namespace {
@@ -55,6 +70,8 @@ protected:
 class mock_usb_control_endpoint : public control_endpoint
 {
 public:
+  using host_event = hal::v5::usb::host_event;
+
   mock_usb_endpoint m_endpoint;
   bool m_should_connect{ false };
   u8 m_address{ 0 };
@@ -64,6 +81,12 @@ public:
   callback<void(on_receive_tag)> m_receive_callback{};
   bool m_on_receive_called{ false };
   std::optional<bool> m_has_setup_state{};
+  callback<void(host_event)> m_host_event_callback{};
+  bool m_on_host_event_called{ false };
+  bool m_remote_wakeup_enabled{ false };
+  bool m_acknowledge_sleep_accept{ false };
+  bool m_acknowledge_sleep_called{ false };
+  bool m_supports_lpm_result{ false };
 
 private:
   [[nodiscard]] endpoint_info driver_info() const override
@@ -112,6 +135,29 @@ private:
   std::optional<bool> driver_has_setup() const noexcept override
   {
     return m_has_setup_state;
+  }
+
+  void driver_on_host_event(
+    hal::callback<void(host_event)> const& p_callback) override
+  {
+    m_host_event_callback = p_callback;
+    m_on_host_event_called = true;
+  }
+
+  void driver_set_remote_wakeup_enabled(bool p_enabled) override
+  {
+    m_remote_wakeup_enabled = p_enabled;
+  }
+
+  void driver_acknowledge_sleep(bool p_accept) override
+  {
+    m_acknowledge_sleep_accept = p_accept;
+    m_acknowledge_sleep_called = true;
+  }
+
+  bool driver_supports_lpm() override
+  {
+    return m_supports_lpm_result;
   }
 };
 
@@ -374,6 +420,8 @@ boost::ut::suite<"usb_control_endpoint_test"> control_endpoint_test = []() {
     expect(that % endpoint.m_endpoint.m_reset_called);
   };
 
+  SUPPRESS_DEPRECATED_START
+
   "mock_usb_control_endpoint has_setup test"_test = []() {
     mock_usb_control_endpoint endpoint;
     endpoint.m_has_setup_state = std::nullopt;
@@ -388,6 +436,8 @@ boost::ut::suite<"usb_control_endpoint_test"> control_endpoint_test = []() {
     auto const val3 = endpoint.has_setup();
     expect(that % false == *val3);
   };
+
+  SUPPRESS_DEPRECATED_END
 
   "mock_usb_control_endpoint default has_setup test"_test = []() {
     struct test_ctrl_ep : public hal::usb::control_endpoint
@@ -421,8 +471,95 @@ boost::ut::suite<"usb_control_endpoint_test"> control_endpoint_test = []() {
       // driver_has_setup skipped!
     } endpoint;
 
+    SUPPRESS_DEPRECATED_START
+
     auto const val1 = endpoint.has_setup();
+
+    SUPPRESS_DEPRECATED_END
+
     expect(std::nullopt == val1);
+  };
+
+  "mock_usb_control_endpoint on_host_event test"_test = []() {
+    using host_event = hal::v5::usb::host_event;
+    mock_usb_control_endpoint endpoint;
+    host_event received_event{};
+
+    auto cb = [&received_event](host_event e) { received_event = e; };
+    endpoint.on_host_event(cb);
+
+    expect(that % endpoint.m_on_host_event_called);
+
+    endpoint.m_host_event_callback(host_event::reset);
+    expect(host_event::reset == received_event);
+
+    endpoint.m_host_event_callback(host_event::enumerated);
+    expect(host_event::enumerated == received_event);
+  };
+
+  "mock_usb_control_endpoint set_remote_wakeup_enabled test"_test = []() {
+    mock_usb_control_endpoint endpoint;
+
+    endpoint.set_remote_wakeup_enabled(true);
+    expect(that % true == endpoint.m_remote_wakeup_enabled);
+
+    endpoint.set_remote_wakeup_enabled(false);
+    expect(that % false == endpoint.m_remote_wakeup_enabled);
+  };
+
+  "mock_usb_control_endpoint acknowledge_sleep test"_test = []() {
+    mock_usb_control_endpoint endpoint;
+
+    endpoint.acknowledge_sleep(true);
+    expect(that % endpoint.m_acknowledge_sleep_called);
+    expect(that % true == endpoint.m_acknowledge_sleep_accept);
+
+    endpoint.acknowledge_sleep(false);
+    expect(that % false == endpoint.m_acknowledge_sleep_accept);
+  };
+
+  "mock_usb_control_endpoint supports_lpm test"_test = []() {
+    mock_usb_control_endpoint endpoint;
+
+    endpoint.m_supports_lpm_result = false;
+    expect(that % false == endpoint.supports_lpm());
+
+    endpoint.m_supports_lpm_result = true;
+    expect(that % true == endpoint.supports_lpm());
+  };
+
+  "control_endpoint default supports_lpm returns false"_test = []() {
+    struct test_ctrl_ep : public hal::usb::control_endpoint
+    {
+      void driver_connect(bool) override
+      {
+      }
+      void driver_set_address(u8) override
+      {
+      }
+      void driver_write(scatter_span<byte const>) override
+      {
+      }
+      usize driver_read(scatter_span<byte>) override
+      {
+        return 0;
+      }
+      void driver_on_receive(callback<void(on_receive_tag)> const&) override
+      {
+      }
+      [[nodiscard]] endpoint_info driver_info() const override
+      {
+        return {};
+      }
+      void driver_stall(bool) override
+      {
+      }
+      void driver_reset() override
+      {
+      }
+    } endpoint;
+
+    expect(that % false == endpoint.supports_lpm());
   };
 };
 
@@ -762,6 +899,8 @@ constexpr u8 iface_desc_type = 0x4;
 
 struct mock : public interface
 {
+  using host_event = hal::v5::usb::host_event;
+
   constexpr static std::array<u8, 9> expected_descriptor = {
     iface_desc_length,
     iface_desc_type,
@@ -807,9 +946,17 @@ struct mock : public interface
     return bytes_read == data.size();
   }
 
+  void driver_handle_host_event(host_event p_event) override
+  {
+    last_host_event = p_event;
+    handle_host_event_called = true;
+  }
+
   descriptor_start write_descriptors_start{};
   setup_packet handle_request_setup{};
   u8 write_string_descriptor_string_index{};
+  host_event last_host_event{};
+  bool handle_host_event_called{ false };
 };
 }  // namespace
 
@@ -872,6 +1019,47 @@ boost::ut::suite<"usb_interface_test"> usb_interface_test = []() {
     expect(that % actual_res);
     expect(that % eio.read_called);
     expect(command == iface.handle_request_setup);
+  };
+
+  "interface::handle_host_event"_test = []() mutable {
+    using host_event = hal::v5::usb::host_event;
+    mock iface;
+
+    iface.handle_host_event(host_event::reset);
+    expect(that % iface.handle_host_event_called);
+    expect(host_event::reset == iface.last_host_event);
+
+    iface.handle_host_event(host_event::suspend_with_wakeup);
+    expect(host_event::suspend_with_wakeup == iface.last_host_event);
+
+    iface.handle_host_event(host_event::resume);
+    expect(host_event::resume == iface.last_host_event);
+  };
+
+  "interface default handle_host_event is no-op"_test = []() mutable {
+    using host_event = hal::v5::usb::host_event;
+    struct noop_iface : public interface
+    {
+      [[nodiscard]] descriptor_count driver_write_descriptors(
+        descriptor_start,
+        endpoint_io&) override
+      {
+        return {};
+      }
+      [[nodiscard]] bool driver_write_string_descriptor(u8,
+                                                        endpoint_io&) override
+      {
+        return false;
+      }
+      bool driver_handle_request(setup_packet const&, endpoint_io&) override
+      {
+        return false;
+      }
+      // driver_handle_host_event not overridden — default is no-op
+    } iface;
+
+    expect(nothrow([&] { iface.handle_host_event(host_event::reset); }));
+    expect(nothrow([&] { iface.handle_host_event(host_event::sleep); }));
   };
 };
 }  // namespace hal::usb

--- a/v4/tests/usb.test.cpp
+++ b/v4/tests/usb.test.cpp
@@ -70,8 +70,7 @@ protected:
 class mock_usb_control_endpoint : public control_endpoint
 {
 public:
-  using host_event = hal::v5::usb::host_event;
-
+  using bus_event = v5::usb::bus_event;
   mock_usb_endpoint m_endpoint;
   bool m_should_connect{ false };
   u8 m_address{ 0 };
@@ -81,12 +80,12 @@ public:
   callback<void(on_receive_tag)> m_receive_callback{};
   bool m_on_receive_called{ false };
   std::optional<bool> m_has_setup_state{};
-  callback<void(host_event)> m_host_event_callback{};
+  callback<void(bus_event)> m_host_event_callback{};
   bool m_on_host_event_called{ false };
   bool m_remote_wakeup_enabled{ false };
   bool m_acknowledge_sleep_accept{ false };
   bool m_acknowledge_sleep_called{ false };
-  bool m_supports_lpm_result{ false };
+  v5::usb::lpm_support m_supports_lpm_result{};
 
 private:
   [[nodiscard]] endpoint_info driver_info() const override
@@ -138,15 +137,20 @@ private:
   }
 
   void driver_on_host_event(
-    hal::callback<void(host_event)> const& p_callback) override
+    hal::callback<void(bus_event)> const& p_callback) override
   {
     m_host_event_callback = p_callback;
     m_on_host_event_called = true;
   }
 
-  void driver_set_remote_wakeup_enabled(bool p_enabled) override
+  void driver_remote_wakeup_enable(bool p_enabled) override
   {
     m_remote_wakeup_enabled = p_enabled;
+  }
+
+  bool driver_remote_wakeup_granted() override
+  {
+    return m_remote_wakeup_enabled;
   }
 
   void driver_acknowledge_sleep(bool p_accept) override
@@ -155,7 +159,7 @@ private:
     m_acknowledge_sleep_called = true;
   }
 
-  bool driver_supports_lpm() override
+  v5::usb::lpm_support driver_supports_lpm() override
   {
     return m_supports_lpm_result;
   }
@@ -481,29 +485,29 @@ boost::ut::suite<"usb_control_endpoint_test"> control_endpoint_test = []() {
   };
 
   "mock_usb_control_endpoint on_host_event test"_test = []() {
-    using host_event = hal::v5::usb::host_event;
+    using bus_event = hal::v5::usb::bus_event;
     mock_usb_control_endpoint endpoint;
-    host_event received_event{};
+    bus_event received_event{};
 
-    auto cb = [&received_event](host_event e) { received_event = e; };
+    auto cb = [&received_event](bus_event e) { received_event = e; };
     endpoint.on_host_event(cb);
 
     expect(that % endpoint.m_on_host_event_called);
 
-    endpoint.m_host_event_callback(host_event::reset);
-    expect(host_event::reset == received_event);
+    endpoint.m_host_event_callback(bus_event::reset);
+    expect(bus_event::reset == received_event);
 
-    endpoint.m_host_event_callback(host_event::enumerated);
-    expect(host_event::enumerated == received_event);
+    endpoint.m_host_event_callback(bus_event::suspend);
+    expect(bus_event::suspend == received_event);
   };
 
-  "mock_usb_control_endpoint set_remote_wakeup_enabled test"_test = []() {
+  "mock_usb_control_endpoint remote_wakeup_enabled test"_test = []() {
     mock_usb_control_endpoint endpoint;
 
-    endpoint.set_remote_wakeup_enabled(true);
+    endpoint.remote_wakeup_enable(true);
     expect(that % true == endpoint.m_remote_wakeup_enabled);
 
-    endpoint.set_remote_wakeup_enabled(false);
+    endpoint.remote_wakeup_enable(false);
     expect(that % false == endpoint.m_remote_wakeup_enabled);
   };
 
@@ -520,12 +524,20 @@ boost::ut::suite<"usb_control_endpoint_test"> control_endpoint_test = []() {
 
   "mock_usb_control_endpoint supports_lpm test"_test = []() {
     mock_usb_control_endpoint endpoint;
+    auto constexpr expected1 = hal::v5::usb::lpm_support()
+                                 .remote_wakeup_supported(true)
+                                 .l1_supported(true)
+                                 .u1_supported(true);
 
-    endpoint.m_supports_lpm_result = false;
-    expect(that % false == endpoint.supports_lpm());
+    endpoint.m_supports_lpm_result = expected1;
+    expect(expected1 == endpoint.supports_lpm());
 
-    endpoint.m_supports_lpm_result = true;
-    expect(that % true == endpoint.supports_lpm());
+    auto constexpr expected2 = hal::v5::usb::lpm_support()
+                                 .l1_supported(true)
+                                 .u1_supported(true)
+                                 .u2_supported(true);
+    endpoint.m_supports_lpm_result = expected2;
+    expect(expected2 == endpoint.supports_lpm());
   };
 
   "control_endpoint default supports_lpm returns false"_test = []() {
@@ -559,7 +571,7 @@ boost::ut::suite<"usb_control_endpoint_test"> control_endpoint_test = []() {
       }
     } endpoint;
 
-    expect(that % false == endpoint.supports_lpm());
+    expect(v5::usb::lpm_support{} == endpoint.supports_lpm());
   };
 };
 

--- a/v4/tests/usb.test.cpp
+++ b/v4/tests/usb.test.cpp
@@ -81,7 +81,7 @@ public:
   bool m_on_receive_called{ false };
   std::optional<bool> m_has_setup_state{};
   callback<void(bus_event)> m_host_event_callback{};
-  bool m_on_host_event_called{ false };
+  bool m_on_bus_event_called{ false };
   bool m_remote_wakeup_enabled{ false };
   bool m_acknowledge_sleep_accept{ false };
   bool m_acknowledge_sleep_called{ false };
@@ -136,11 +136,11 @@ private:
     return m_has_setup_state;
   }
 
-  void driver_on_host_event(
+  void driver_on_bus_event(
     hal::callback<void(bus_event)> const& p_callback) override
   {
     m_host_event_callback = p_callback;
-    m_on_host_event_called = true;
+    m_on_bus_event_called = true;
   }
 
   void driver_remote_wakeup_enable(bool p_enabled) override
@@ -484,15 +484,15 @@ boost::ut::suite<"usb_control_endpoint_test"> control_endpoint_test = []() {
     expect(std::nullopt == val1);
   };
 
-  "mock_usb_control_endpoint on_host_event test"_test = []() {
+  "mock_usb_control_endpoint on_bus_event test"_test = []() {
     using bus_event = hal::v5::usb::bus_event;
     mock_usb_control_endpoint endpoint;
     bus_event received_event{};
 
     auto cb = [&received_event](bus_event e) { received_event = e; };
-    endpoint.on_host_event(cb);
+    endpoint.on_bus_event(cb);
 
-    expect(that % endpoint.m_on_host_event_called);
+    expect(that % endpoint.m_on_bus_event_called);
 
     endpoint.m_host_event_callback(bus_event::reset);
     expect(bus_event::reset == received_event);
@@ -509,6 +509,50 @@ boost::ut::suite<"usb_control_endpoint_test"> control_endpoint_test = []() {
 
     endpoint.remote_wakeup_enable(false);
     expect(that % false == endpoint.m_remote_wakeup_enabled);
+  };
+
+  "mock_usb_control_endpoint remote_wakeup_granted test"_test = []() {
+    mock_usb_control_endpoint endpoint;
+
+    endpoint.remote_wakeup_enable(true);
+    expect(that % true == endpoint.remote_wakeup_granted());
+
+    endpoint.remote_wakeup_enable(false);
+    expect(that % false == endpoint.remote_wakeup_granted());
+  };
+
+  "control_endpoint default remote_wakeup_granted returns false"_test = []() {
+    struct test_ctrl_ep : public hal::usb::control_endpoint
+    {
+      void driver_connect(bool) override
+      {
+      }
+      void driver_set_address(u8) override
+      {
+      }
+      void driver_write(scatter_span<byte const>) override
+      {
+      }
+      usize driver_read(scatter_span<byte>) override
+      {
+        return 0;
+      }
+      void driver_on_receive(callback<void(on_receive_tag)> const&) override
+      {
+      }
+      [[nodiscard]] endpoint_info driver_info() const override
+      {
+        return {};
+      }
+      void driver_stall(bool) override
+      {
+      }
+      void driver_reset() override
+      {
+      }
+    } endpoint;
+
+    expect(that % false == endpoint.remote_wakeup_granted());
   };
 
   "mock_usb_control_endpoint acknowledge_sleep test"_test = []() {
@@ -875,6 +919,89 @@ boost::ut::suite<"usb_specific_endpoint_test"> specific_endpoint_test = []() {
 
 namespace hal::usb {
 
+boost::ut::suite<"lpm_support_test"> lpm_support_test = []() {
+  using namespace boost::ut;
+  using hal::v5::usb::lpm_support;
+
+  "lpm_support default is all zeros"_test = []() {
+    lpm_support s{};
+    expect(that % false == s.remote_wakeup_supported());
+    expect(that % false == s.l1_supported());
+    expect(that % false == s.u1_supported());
+    expect(that % false == s.u2_supported());
+    expect(that % s.none());
+    expect(that % not s.any());
+  };
+
+  "lpm_support setters enable individual bits"_test = []() {
+    lpm_support s{};
+
+    s.remote_wakeup_supported(true);
+    expect(that % s.remote_wakeup_supported());
+    expect(that % not s.l1_supported());
+    expect(that % not s.u1_supported());
+    expect(that % not s.u2_supported());
+    expect(that % s.any());
+    expect(that % not s.none());
+
+    s.remote_wakeup_supported(false);
+    expect(that % not s.remote_wakeup_supported());
+
+    s.l1_supported(true);
+    expect(that % s.l1_supported());
+    s.l1_supported(false);
+    expect(that % not s.l1_supported());
+
+    s.u1_supported(true);
+    expect(that % s.u1_supported());
+    s.u1_supported(false);
+    expect(that % not s.u1_supported());
+
+    s.u2_supported(true);
+    expect(that % s.u2_supported());
+    s.u2_supported(false);
+    expect(that % not s.u2_supported());
+  };
+
+  "lpm_support method chaining"_test = []() {
+    auto s = lpm_support{}
+               .remote_wakeup_supported(true)
+               .l1_supported(true)
+               .u1_supported(true)
+               .u2_supported(true);
+
+    expect(that % s.remote_wakeup_supported());
+    expect(that % s.l1_supported());
+    expect(that % s.u1_supported());
+    expect(that % s.u2_supported());
+    expect(that % s.any());
+    expect(that % not s.none());
+  };
+
+  "lpm_support set() directly"_test = []() {
+    lpm_support s{};
+    s.set(lpm_support::l1_mask, true);
+    expect(that % s.l1_supported());
+    expect(that % not s.u1_supported());
+
+    s.set(lpm_support::l1_mask, false);
+    expect(that % not s.l1_supported());
+  };
+
+  "lpm_support operator<=>"_test = []() {
+    auto a = lpm_support{}.l1_supported(true);
+    auto b = lpm_support{}.l1_supported(true);
+    auto c = lpm_support{}.u1_supported(true);
+
+    expect(a == b);
+    expect(a != c);
+  };
+};
+
+}  // namespace hal::usb
+
+namespace hal::usb {
+
 namespace {
 
 template<typename T>
@@ -992,6 +1119,269 @@ boost::ut::suite<"usb_iterface_req_bitmap_test"> req_bitmap_test = []() {
     expect(that % true == bm.is_device_to_host());
   };
 };
+
+boost::ut::suite<"setup_packet_test"> setup_packet_test = []() {
+  using namespace boost::ut;
+
+  "setup_packet default constructor"_test = []() {
+    setup_packet pkt{};
+    expect(that % 0 == pkt.bm_request_type());
+    expect(that % 0 == pkt.request());
+    expect(that % 0 == pkt.value());
+    expect(that % 0 == pkt.index());
+    expect(that % 0 == pkt.length());
+  };
+
+  "setup_packet construction from args"_test = []() {
+    setup_packet pkt(setup_packet::args{
+      .device_to_host = true,
+      .type = setup_packet::request_type::class_t,
+      .recipient = setup_packet::request_recipient::interface,
+      .request = 0x09,
+      .value = 0x0301,
+      .index = 0x0002,
+      .length = 0x0008,
+    });
+
+    expect(that % true == pkt.is_device_to_host());
+    expect(setup_packet::request_type::class_t == pkt.get_type());
+    expect(setup_packet::request_recipient::interface == pkt.get_recipient());
+    expect(that % u8{ 0x09 } == pkt.request());
+    expect(that % u16{ 0x0301 } == pkt.value());
+    expect(that % u16{ 0x0002 } == pkt.index());
+    expect(that % u16{ 0x0008 } == pkt.length());
+  };
+
+  "setup_packet bm_request_type and request fields"_test = []() {
+    // device-to-host | vendor | endpoint recipient
+    std::array<byte, 8> raw{
+      byte{ 0b11000010 }, byte{ 0x42 }, 0, 0, 0, 0, 0, 0
+    };
+    setup_packet pkt(raw);
+
+    expect(that % byte{ 0b11000010 } == byte{ pkt.bm_request_type() });
+    expect(that % byte{ 0x42 } == byte{ pkt.request() });
+    expect(setup_packet::request_type::vendor == pkt.get_type());
+    expect(setup_packet::request_recipient::endpoint == pkt.get_recipient());
+    expect(that % true == pkt.is_device_to_host());
+  };
+
+  "setup_packet value getter and setter"_test = []() {
+    setup_packet pkt{};
+    pkt.value(0x1234);
+    expect(that % u16{ 0x1234 } == pkt.value());
+
+    auto vb = pkt.value_bytes();
+    expect(that % 2 == vb.size());
+    expect(that % byte{ 0x34 } == vb[0]);
+    expect(that % byte{ 0x12 } == vb[1]);
+  };
+
+  "setup_packet index getter and setter"_test = []() {
+    setup_packet pkt{};
+    pkt.index(0xABCD);
+    expect(that % u16{ 0xABCD } == pkt.index());
+
+    auto ib = pkt.index_bytes();
+    expect(that % 2 == ib.size());
+    expect(that % byte{ 0xCD } == ib[0]);
+    expect(that % byte{ 0xAB } == ib[1]);
+  };
+
+  "setup_packet length getter and setter"_test = []() {
+    setup_packet pkt{};
+    pkt.length(0x0040);
+    expect(that % u16{ 0x0040 } == pkt.length());
+
+    auto lb = pkt.length_bytes();
+    expect(that % 2 == lb.size());
+    expect(that % byte{ 0x40 } == lb[0]);
+    expect(that % byte{ 0x00 } == lb[1]);
+  };
+
+  "setup_packet operator=="_test = []() {
+    std::array<byte, 8> raw{ byte{ 0x80 }, byte{ 0x06 }, byte{ 0x00 },
+                             byte{ 0x01 }, byte{ 0x00 }, byte{ 0x00 },
+                             byte{ 0x12 }, byte{ 0x00 } };
+    setup_packet a(raw);
+    setup_packet b(raw);
+    setup_packet c{};
+
+    expect(a == b);
+    expect(a != c);
+  };
+
+  "setup_packet get_type invalid"_test = []() {
+    // bits 6-5 = 0b11 (value 3) is reserved/invalid
+    std::array<byte, 8> raw{ byte{ 0b01100000 }, 0, 0, 0, 0, 0, 0, 0 };
+    setup_packet pkt(raw);
+    expect(setup_packet::request_type::invalid == pkt.get_type());
+  };
+
+  "setup_packet get_recipient invalid"_test = []() {
+    // bits 4-0 = 3 is reserved/invalid
+    std::array<byte, 8> raw{ byte{ 0x03 }, 0, 0, 0, 0, 0, 0, 0 };
+    setup_packet pkt(raw);
+    expect(setup_packet::request_recipient::invalid == pkt.get_recipient());
+  };
+
+  "setup_packet from_le_bytes"_test = []() {
+    auto result = setup_packet::from_le_bytes(byte{ 0x34 }, byte{ 0x12 });
+    expect(that % u16{ 0x1234 } == result);
+  };
+
+  "setup_packet to_le_u16"_test = []() {
+    auto arr = setup_packet::to_le_u16(0xABCD);
+    expect(that % byte{ 0xCD } == arr[0]);
+    expect(that % byte{ 0xAB } == arr[1]);
+  };
+};
+
+boost::ut::suite<"determine_standard_request_test"> std_request_test = []() {
+  using namespace boost::ut;
+
+  "determine_standard_request valid standard requests"_test = []() {
+    auto make = [](u8 req) {
+      return setup_packet(setup_packet::args{
+        .device_to_host = false,
+        .type = setup_packet::request_type::standard,
+        .recipient = setup_packet::request_recipient::device,
+        .request = req,
+        .value = 0,
+        .index = 0,
+        .length = 0,
+      });
+    };
+
+    expect(standard_request_types::get_status ==
+           determine_standard_request(make(0x00)));
+    expect(standard_request_types::clear_feature ==
+           determine_standard_request(make(0x01)));
+    expect(standard_request_types::set_feature ==
+           determine_standard_request(make(0x03)));
+    expect(standard_request_types::set_address ==
+           determine_standard_request(make(0x05)));
+    expect(standard_request_types::get_descriptor ==
+           determine_standard_request(make(0x06)));
+    expect(standard_request_types::set_descriptor ==
+           determine_standard_request(make(0x07)));
+    expect(standard_request_types::get_configuration ==
+           determine_standard_request(make(0x08)));
+    expect(standard_request_types::set_configuration ==
+           determine_standard_request(make(0x09)));
+    expect(standard_request_types::get_interface ==
+           determine_standard_request(make(0x0A)));
+    expect(standard_request_types::set_interface ==
+           determine_standard_request(make(0x11)));
+    expect(standard_request_types::synch_frame ==
+           determine_standard_request(make(0x12)));
+  };
+
+  "determine_standard_request returns invalid for non-standard type"_test =
+    []() {
+      setup_packet pkt(setup_packet::args{
+        .device_to_host = false,
+        .type = setup_packet::request_type::class_t,
+        .recipient = setup_packet::request_recipient::device,
+        .request = 0x06,
+        .value = 0,
+        .index = 0,
+        .length = 0,
+      });
+      expect(standard_request_types::invalid ==
+             determine_standard_request(pkt));
+    };
+
+  "determine_standard_request returns invalid for reserved request 0x04"_test =
+    []() {
+      setup_packet pkt(setup_packet::args{
+        .device_to_host = false,
+        .type = setup_packet::request_type::standard,
+        .recipient = setup_packet::request_recipient::device,
+        .request = 0x04,
+        .value = 0,
+        .index = 0,
+        .length = 0,
+      });
+      expect(standard_request_types::invalid ==
+             determine_standard_request(pkt));
+    };
+
+  "determine_standard_request returns invalid for out-of-range request"_test =
+    []() {
+      setup_packet pkt(setup_packet::args{
+        .device_to_host = false,
+        .type = setup_packet::request_type::standard,
+        .recipient = setup_packet::request_recipient::device,
+        .request = 0x13,
+        .value = 0,
+        .index = 0,
+        .length = 0,
+      });
+      expect(standard_request_types::invalid ==
+             determine_standard_request(pkt));
+    };
+};
+
+boost::ut::suite<"endpoint_io_test"> endpoint_io_test = []() {
+  using namespace boost::ut;
+
+  "endpoint_io read"_test = []() {
+    mock_endpoint_io eio;
+    std::array<byte, 4> buf{};
+    auto ss = make_writable_scatter_bytes(buf);
+
+    expect(that % not eio.read_called);
+    auto n = eio.read(ss);
+    expect(that % eio.read_called);
+    expect(that % usize{ 4 } == n);
+  };
+
+  "endpoint_io write"_test = []() {
+    mock_endpoint_io eio;
+    std::array<byte, 3> data{ byte{ 1 }, byte{ 2 }, byte{ 3 } };
+    auto ss = make_scatter_bytes(data);
+
+    expect(that % not eio.write_called);
+    auto n = eio.write(ss);
+    expect(that % eio.write_called);
+    expect(that % usize{ 3 } == n);
+  };
+};
+
+boost::ut::suite<"interface_descriptor_types_test"> descriptor_types_test =
+  []() {
+    using namespace boost::ut;
+    using descriptor_count = interface::descriptor_count;
+    using descriptor_start = interface::descriptor_start;
+
+    "descriptor_count operator<=>"_test = []() {
+      descriptor_count a{ 1, 2 };
+      descriptor_count b{ 1, 2 };
+      descriptor_count c{ 2, 1 };
+
+      expect(a == b);
+      expect(a != c);
+    };
+
+    "descriptor_start operator<=>"_test = []() {
+      descriptor_start a{ .interface = 0, .string = 1 };
+      descriptor_start b{ .interface = 0, .string = 1 };
+      descriptor_start c{ .interface = 1, .string = 0 };
+
+      expect(a == b);
+      expect(a != c);
+    };
+
+    "descriptor_start with nullopt"_test = []() {
+      descriptor_start a{ .interface = std::nullopt, .string = std::nullopt };
+      descriptor_start b{ .interface = std::nullopt, .string = std::nullopt };
+      descriptor_start c{ .interface = 0, .string = std::nullopt };
+
+      expect(a == b);
+      expect(a != c);
+    };
+  };
 
 // Test the usb highlevel interface (interface descriptor level)
 boost::ut::suite<"usb_interface_test"> usb_interface_test = []() {


### PR DESCRIPTION
- Add `host_event` enum covering the full USB power-state vocabulary: reset, setup_packet, data_packet, enumerated, resume, suspend_with_wakeup, suspend_without_wakeup, sleep (L1/LPM), u1_sleep, u2_sleep (USB 3.0+)
- Add `control_endpoint::on_host_event()` — registers a callback invoked from interrupt context on any host event; default virtual throws `operation_not_supported`
- Add `control_endpoint::set_remote_wakeup_enabled()` — called by the enumerator in response to SET/CLEAR_FEATURE(DEVICE_REMOTE_WAKEUP); default virtual throws `operation_not_supported`
- Add `control_endpoint::acknowledge_sleep()` — called by the enumerator when an LPM token arrives to accept or reject L1 sleep; default virtual throws `operation_not_supported`
- Add `control_endpoint::supports_lpm()` — queried during enumeration to decide whether to advertise a BOS/LPM descriptor; default returns false
- Deprecate `control_endpoint::has_setup()` with `[[deprecated]]` pointing to `on_host_event` + `host_event::setup_packet` as replacement
- Add `interface::on_host_event()` expand doc comment with per-event guidance for all power states
- Document that `endpoint_io::write` throws `operation_not_permitted` when the bus is suspended without remote wakeup capability
- Add `error.hpp` include to `usb.hpp` for `operation_not_supported`
- Add unit tests for all new APIs and their default virtual behaviors; suppress `-Wdeprecated-declarations` around existing `has_setup` tests.