### PR TITLE
:sparkles: Add can interfaces to v5

### DIFF
--- a/v5/CMakeLists.txt
+++ b/v5/CMakeLists.txt
@@ -65,4 +65,5 @@ libhal_add_tests(libhal
         serial
         containers
         sensors
+        can
 )

--- a/v5/CMakeLists.txt
+++ b/v5/CMakeLists.txt
@@ -29,6 +29,7 @@ libhal_add_library(libhal
     MODULES
         modules/hal.cppm
         modules/analog.cppm
+        modules/can.cppm
         modules/units.cppm
         modules/gpio.cppm
         modules/sensors.cppm

--- a/v5/modules/can.cppm
+++ b/v5/modules/can.cppm
@@ -1,4 +1,4 @@
-// Copyright 2024 - 2025 Khalil Estell and the libhal contributors
+// Copyright 2026 Khalil Estell and the libhal contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@ module;
 
 #include <array>
 #include <optional>
-#include <span>
 
 export module hal:can;
 
 export import async_context;
 import :units;
+import :containers;
 
 namespace hal::inline v5 {
 /**
@@ -149,7 +149,7 @@ public:
   /**
    * @return the device's operating baud rate in hertz
    */
-  async::future<u32> baud_rate(async::context& p_context)
+  async::future<hertz> baud_rate(async::context& p_context)
   {
     return driver_baud_rate(p_context);
   }
@@ -159,6 +159,7 @@ public:
    *
    * @param p_context - async context for coroutine suspension and resumption.
    * @param p_message - a message to be sent over the can network
+   * @return async::future<void> - completes when the message is sent
    * @throws hal::operation_not_permitted - or a derivative of this class, if
    *         the can device has entered the "bus-off" state. This can happen if
    *         a critical fault in the bus has occurred. A call to `bus_on()`
@@ -181,13 +182,12 @@ public:
    *
    * This API will work even if the CAN peripheral is "bus-off".
    *
-   * @return std::span<message const> - constant span to the message receive
-   *         buffer used by this driver. Assume the lifetime of the buffer is
-   *         the same as the class's lifetime. When the memory of the owning
-   *         object is invalidated, so is this span. Calling `size()` on the
-   *         span will always return a value of at least 1.
+   * @return circular_span<can_message const> - a const span to the
+   * receive buffer used by the transceiver. Calling `size()` on the span will
+   * always return a value of at least 1. Holds messages accepted by the can
+   * message filter that were seen on the can bus.
    */
-  std::span<can_message const> receive_buffer()
+  circular_span<can_message const> receive_buffer()
   {
     return driver_receive_buffer();
   }
@@ -236,10 +236,10 @@ public:
   virtual ~can_transceiver() = default;
 
 private:
-  virtual async::future<u32> driver_baud_rate(async::context& p_context) = 0;
+  virtual async::future<hertz> driver_baud_rate(async::context& p_context) = 0;
   virtual async::future<void> driver_send(async::context& p_context,
                                           can_message const& p_message) = 0;
-  virtual std::span<can_message const> driver_receive_buffer() = 0;
+  virtual circular_span<can_message const> driver_receive_buffer() = 0;
   virtual usize driver_receive_cursor() = 0;
 };
 
@@ -254,13 +254,14 @@ private:
  * message is received. If message filtering is enabled, then the callback will
  * only be for messages received through the filter.
  */
-class can_interrupt
+export class can_interrupt
 {
 public:
   /**
-   * @brief Set a callback to occur when a new message has been received
+   * @brief Wait for a new message reception event
    *
    * @param p_context - async context for coroutine suspension and resumption.
+   * @return async::future<void> - completes when a message is received
    */
   async::future<void> on_receive(async::context& p_context)
   {
@@ -274,6 +275,20 @@ private:
 };
 
 /**
+ * @brief Message acceptance mode for the can bus
+ *
+ */
+export enum class can_message_acceptance : u8 {
+  /// Accept no messages over the bus
+  none,
+  /// Accept all messages, ignore all filters
+  all,
+  /// Only accept messages that pass through filters. If no filters have been
+  /// setup, then no messages will be received.
+  filtered,
+};
+
+/**
  * @brief CAN Bus configuration & control hardware abstraction interface
  *
  * Implementations of this interface are NOT sharable across multiple device or
@@ -281,24 +296,9 @@ private:
  * control the CAN bus.
  *
  */
-class can_bus_manager
+export class can_bus_manager
 {
 public:
-  /**
-   * @brief Message acceptance mode for the can bus
-   *
-   */
-  enum class accept : u8
-  {
-    /// Accept no messages over the bus
-    none,
-    /// Accept all messages, ignore all filters
-    all,
-    /// Only accept messages that pass through filters. If no filters have been
-    /// setup, then no messages will be received.
-    filtered,
-  };
-
   /**
    * @brief Set the can bus baud rate
    *
@@ -314,6 +314,7 @@ public:
    *
    * @param p_context - async context for coroutine suspension and resumption.
    * @param p_hertz - baud rate in hertz
+   * @return async::future<void> - completes when the baud rate is set
    * @throws hal::operation_not_supported if the baud rate is above or below
    * what the device can support.
    */
@@ -327,30 +328,35 @@ public:
    *
    * @param p_context - async context for coroutine suspension and resumption.
    * @param p_accept - defines the set of messages that will be accepted. See
-   * the `accept` enum class for details about each option and what they do.
+   * the `can_message_acceptance` enum class for details about each option and
+   * what they do.
+   * @return async::future<void> - completes when the filter mode is set
    */
-  async::future<void> filter_mode(async::context& p_context, accept p_accept)
+  async::future<void> filter_mode(async::context& p_context,
+                                  can_message_acceptance p_accept)
   {
     return driver_filter_mode(p_context, p_accept);
   }
 
   /**
-   * @brief Set a callback for when the CAN device goes bus-off
+   * @brief Wait for a bus-off event
    *
    * The BUS-OFF state for CAN is denoted by the occurrence of too many
    * transmission errors (TEC > 255) causing the CAN controller to disconnect
    * from the bus to prevent further network disruption. During bus-off,
    * the node cannot transmit or receive any messages.
    *
-   * On construction of the can driver, the default callback for the bus-off
-   * event is to do nothing. The `send()` API throw the
+   * On construction of the can driver, the device starts in the "bus-on" state.
+   * When this event completes, the `send()` API will throw the
    * `hal::operation_not_permitted` exception and the `receive_cursor()` API
    * will not update.
    *
-   * Care should be taken when writing the callback, as it will most likely be
-   * executed in an interrupt context.
+   * Care should be taken when awaiting this event, as it will most likely be
+   * triggered from an interrupt context.
    *
    * @param p_context - async context for coroutine suspension and resumption.
+   * @return async::future<void> - completes when the device enters bus-off
+   * state
    */
   async::future<void> on_bus_off(async::context& p_context)
   {
@@ -377,6 +383,8 @@ public:
    * called to re-enable bus communication.
    *
    * @param p_context - async context for coroutine suspension and resumption.
+   * @return async::future<void> - completes when the device transitions to
+   * bus-on
    */
   async::future<void> bus_on(async::context& p_context)
   {
@@ -388,345 +396,152 @@ public:
 private:
   virtual async::future<void> driver_baud_rate(async::context& p_context,
                                                hal::u32 p_hertz) = 0;
-  virtual async::future<void> driver_filter_mode(async::context& p_context,
-                                                 accept p_accept) = 0;
+  virtual async::future<void> driver_filter_mode(
+    async::context& p_context,
+    can_message_acceptance p_accept) = 0;
   virtual async::future<void> driver_on_bus_off(async::context& p_context) = 0;
   virtual async::future<void> driver_bus_on(async::context& p_context) = 0;
 };
 
 /**
- * @brief CAN message ID filter hardware abstraction interface
+ * @brief Base interface for CAN message filtering
  *
- * On construction, implementations acquire/reserve resources for filtering the
- * message passed to the `allow()` API. On destruction, those resources should
- * be freed such that another can_identifier_filter can claim them. In general,
- * filters of all sorts are limited in the number and type of filters they
- * support.
+ * Provides a generic mechanism for implementing CAN message filters that can
+ * accept or reject messages based on a template parameter type. Implementations
+ * must override the driver_allow method to handle the actual filtering logic.
+ *
+ * @tparam Allowed - The type of filtering criteria (e.g., u16 for ID, can_mask
+ *                   for mask-based filtering, can_range for range-based
+ *                   filtering)
  */
-class can_identifier_filter
+export template<typename Allowed>
+class can_filter
 {
 public:
   /**
-   * @brief Allow messages with this identifier to pass the can bus filter
+   * @brief Configure the filter acceptance criteria
    *
-   * This filter does not distinguish between remote request frames and data
-   * frames. Frames of either type will be allowed so long as the message
-   * identifier matches.
+   * Asynchronously updates the filter to accept messages matching the specified
+   * criteria. If p_allowed is nullopt, the filter may be cleared or disabled
+   * depending on the implementation.
    *
-   * @param p_context - async context for coroutine suspension and resumption.
-   * @param p_id - Allow messages with this ID through to the can message
-   * filter. To stop allowing messages from this filter, set this parameter to
-   * `std::nullopt`.
-   */
-  async::future<void> allow(async::context& p_context, std::optional<u16> p_id)
-  {
-    return driver_allow(p_context, p_id);
-  }
-
-  virtual ~can_identifier_filter() = default;
-
-private:
-  virtual async::future<void> driver_allow(async::context& p_context,
-                                           std::optional<u16> p_id) = 0;
-};
-
-/**
- * @brief CAN message extended ID filter hardware abstraction interface
- *
- * On construction, implementations acquire/reserve resources for filtering the
- * message passed to the `allow()` API. On destruction, those resources should
- * be freed such that another can_identifier_filter can claim them. In general,
- * filters of all sorts are limited in the number and type of filters they
- * support.
- */
-class can_extended_identifier_filter
-{
-public:
-  /**
-   * @brief Allow messages with this identifier to pass the can bus filter
-   *
-   * This filter does not distinguish between remote request frames and data
-   * frames. Frames of either type will be allowed so long as the message
-   * identifier matches.
-   *
-   * @param p_context - async context for coroutine suspension and resumption.
-   * @param p_id - Allow messages with this ID through to the can message
-   * filter. To stop allowing messages from this filter, set this parameter to
-   * `std::nullopt`.
-   */
-  async::future<void> allow(async::context& p_context, std::optional<u32> p_id)
-  {
-    return driver_allow(p_context, p_id);
-  }
-
-  virtual ~can_extended_identifier_filter() = default;
-
-private:
-  virtual async::future<void> driver_allow(async::context& p_context,
-                                           std::optional<u32> p_id) = 0;
-};
-
-/**
- * @brief CAN message mask filter hardware abstraction interface
- *
- * On construction, implementations acquire/reserve resources for filtering the
- * message passed to the `allow()` API. On destruction, those resources should
- * be freed such that another can_identifier_filter can claim them. In general,
- * filters of all sorts are limited in the number and type of filters they
- * support.
- */
-class can_mask_filter
-{
-public:
-  /**
-   * @brief Mask filter
-   *
-   * The following equation must be true in order for the message to pass the
-   * can bus filter.
-   *
-   *     received_message_id & mask == id & mask
-   */
-  struct pair
-  {
-    /**
-     * @brief Specifies an ID to match against
-     *
-     */
-    u16 id = 0;
-    /**
-     * @brief Specifies which bits of the ID to consider.
-     *
-     * For example, a mask of 0x7FF would match all bits in a 11-bit ID since
-     * all 11 bits are set. A mask of 0x7F0, would allow messages with the most
-     * significant 7 bits of the ID and the lower 4 bits can be any value.
-     *
-     */
-    u16 mask = 0;
-    /**
-     * @brief Enables default comparison
-     *
-     */
-    constexpr bool operator<=>(pair const&) const = default;
-  };
-
-  /**
-   * @brief Allow messages that correspond to this mask pass the can bus filter
-   *
-   * This filter does not distinguish between remote request frames and data
-   * frames. Frames of either type will be allowed so long as the message
-   * identifier matches.
-   *
-   * @param p_context - async context for coroutine suspension and resumption.
-   * @param p_filter_pair - mask filter used to filter incoming messages. To
-   * stop allowing messages from this filter, set this parameter to
-   * `std::nullopt`.
+   * @param p_context - The async execution context for this operation
+   * @param p_allowed - The filtering criteria; nullopt to clear the filter
+   * @return async::future<void> - Completes when the filter is configured
    */
   async::future<void> allow(async::context& p_context,
-                            std::optional<pair> p_filter_pair)
+                            std::optional<Allowed> p_allowed)
   {
-    return driver_allow(p_context, p_filter_pair);
+    return driver_allow(p_context, p_allowed);
   }
-
-  virtual ~can_mask_filter() = default;
+  virtual ~can_filter() = default;
 
 private:
-  virtual async::future<void> driver_allow(
-    async::context& p_context,
-    std::optional<pair> p_filter_pair) = 0;
+  virtual async::future<void> driver_allow(async::context&,
+                                           std::optional<Allowed>) = 0;
 };
 
 /**
- * @brief CAN message extended mask filter hardware abstraction interface
+ * @brief Standard CAN ID mask filter configuration
  *
- * On construction, implementations acquire/reserve resources for filtering the
- * message passed to the `allow()` API. On destruction, those resources should
- * be freed such that another can_identifier_filter can claim them. In general,
- * filters of all sorts are limited in the number and type of filters they
- * support.
+ * Defines a mask-based filter for standard (11-bit) CAN message IDs using
+ * an id value and a bit mask. A message matches the filter if:
+ * (message_id & mask) == id
+ *
  */
-class can_extended_mask_filter
+export struct can_mask
 {
-public:
-  /**
-   * @brief Extended mask filter
-   *
-   * The following equation must be true in order for the message to pass the
-   * can bus filter.
-   *
-   *     received_message_id & mask == id & mask
-   */
-  struct pair
-  {
-    /**
-     * @brief Specifies an ID to match against
-     *
-     */
-    u32 id = 0;
-    /**
-     * @brief Specifies which bits of the ID to consider.
-     *
-     * For example, a mask of 0x1FFFFFFF would match all bits in a 29-bit ID
-     * since all 29 bits are set. A mask of 0x1FFFFFF0, would allow messages
-     * with the most significant 25 bits of the ID and the lower 4 bits can be
-     * any value.
-     *
-     */
-    u32 mask = 0;
-    /**
-     * @brief Enables default comparison
-     *
-     */
-    constexpr bool operator<=>(pair const&) const = default;
-  };
-
-  /**
-   * @brief Set the allowed messages through a mask filter.
-   *
-   * This filter does not distinguish between remote request frames and data
-   * frames. Frames of either type will be allowed so long as the message
-   * identifier matches.
-   *
-   * This filter can be used to both standard and extended identifier frames.
-   * Implements should disregard the IDE bit if their platforms support
-   * filtering based on this bit.
-   *
-   * @param p_context - async context for coroutine suspension and resumption.
-   * @param p_filter_pair - mask filter used to filter incoming messages. Set
-   * this to `std::nullopt` to disengage this filter.
-   */
-  async::future<void> allow(async::context& p_context,
-                            std::optional<pair> p_filter_pair)
-  {
-    return driver_allow(p_context, p_filter_pair);
-  }
-
-  virtual ~can_extended_mask_filter() = default;
-
-private:
-  virtual async::future<void> driver_allow(
-    async::context& p_context,
-    std::optional<pair> p_filter_pair) = 0;
+  u16 id = 0;
+  u16 mask = 0;
+  constexpr auto operator<=>(can_mask const&) const = default;
 };
 
 /**
- * @brief CAN message range filter hardware abstraction interface
+ * @brief Extended CAN ID mask filter configuration
  *
- * On construction, implementations acquire/reserve resources for filtering the
- * message passed to the `allow()` API. On destruction, those resources should
- * be freed such that another can_identifier_filter can claim them. In general,
- * filters of all sorts are limited in the number and type of filters they
- * support.
+ * Defines a mask-based filter for extended (29-bit) CAN message IDs using
+ * an id value and a bit mask. A message matches the filter if:
+ * (message_id & mask) == id
+ *
  */
-class can_range_filter
+export struct can_mask_ext
 {
-public:
-  /**
-   * @brief filter pair information
-   *
-   * id_1 and id_2 constitute a range of allowed IDs. They do NOT need to be
-   * ordered relative to each other. Meaning id_1 < id_2 is not required or
-   * necessary. Setting id_1 and id_2 to the same value allowed and will act
-   * like can_identifier_mask.
-   */
-  struct pair
-  {
-    /**
-     * @brief Specifies one end of the id range bounds.
-     *
-     */
-    u16 id_1 = 0;
-    /**
-     * @brief Specifies the other end of the id range bounds
-     *
-     */
-    u16 id_2 = 0;
-    /**
-     * @brief Enables default comparison
-     *
-     */
-    constexpr bool operator<=>(pair const&) const = default;
-  };
-
-  /**
-   * @brief Allow messages within this id range to pass the can bus filter
-   *
-   * @param p_context - async context for coroutine suspension and resumption.
-   * @param p_filter_pair - allow this range of IDs through the can filter. To
-   * stop allowing messages from this filter, set this parameter to
-   * `std::nullopt`.
-   */
-  async::future<void> allow(async::context& p_context,
-                            std::optional<pair> p_filter_pair)
-  {
-    return driver_allow(p_context, p_filter_pair);
-  }
-
-  virtual ~can_range_filter() = default;
-
-private:
-  virtual async::future<void> driver_allow(
-    async::context& p_context,
-    std::optional<pair> p_filter_pair) = 0;
+  u32 id = 0;
+  u32 mask = 0;
+  constexpr auto operator<=>(can_mask_ext const&) const = default;
 };
 
 /**
- * @brief CAN message extended range filter hardware abstraction interface
+ * @brief Standard CAN ID range filter configuration
  *
- * On construction, implementations acquire/reserve resources for filtering the
- * message passed to the `allow()` API. On destruction, those resources should
- * be freed such that another can_identifier_filter can claim them. In general,
- * filters of all sorts are limited in the number and type of filters they
- * support.
+ * Defines a range-based filter for standard (11-bit) CAN message IDs using
+ * lower and upper ID bounds (id_1 and id_2). A message matches the filter if:
+ * id_1 <= message_id <= id_2
+ *
  */
-class can_extended_range_filter
+export struct can_range
 {
-public:
-  /**
-   * @brief Range filter
-   *
-   * id_1 and id_2 constitute a range of allowed IDs. They do NOT need to be
-   * ordered relative to each other. Meaning id_1 < id_2 is not required or
-   * necessary. Setting id_1 and id_2 to the same value allowed and will act
-   * like can_identifier_mask.
-   */
-  struct pair
-  {
-    /**
-     * @brief Specifies one end of the id range bounds.
-     *
-     */
-    u32 id_1 = 0;
-    /**
-     * @brief Specifies the other end of the id range bounds
-     *
-     */
-    u32 id_2 = 0;
-    /**
-     * @brief Enables default comparison
-     *
-     */
-    constexpr bool operator<=>(pair const&) const = default;
-  };
-
-  /**
-   * @brief Set the allowed messages through a range filter.
-   *
-   * @param p_context - async context for coroutine suspension and resumption.
-   * @param p_filter_pair - allow this range of IDs through the can filter. To
-   * stop allowing messages from this filter, set this parameter to
-   * `std::nullopt`.
-   */
-  async::future<void> allow(async::context& p_context,
-                            std::optional<pair> p_filter_pair)
-  {
-    return driver_allow(p_context, p_filter_pair);
-  }
-
-  virtual ~can_extended_range_filter() = default;
-
-private:
-  virtual async::future<void> driver_allow(
-    async::context& p_context,
-    std::optional<pair> p_filter_pair) = 0;
+  u16 id_1 = 0;
+  u16 id_2 = 0;
+  constexpr auto operator<=>(can_range const&) const = default;
 };
+
+/**
+ * @brief Extended CAN ID range filter configuration
+ *
+ * Defines a range-based filter for extended (29-bit) CAN message IDs using
+ * lower and upper ID bounds (id_1 and id_2). A message matches the filter if:
+ * id_1 <= message_id <= id_2
+ *
+ */
+export struct can_range_ext
+{
+  u32 id_1 = 0;
+  u32 id_2 = 0;
+  constexpr auto operator<=>(can_range_ext const&) const = default;
+};
+
+/**
+ * @brief Filter accepting standard CAN message IDs
+ *
+ * Filters messages by single 11-bit CAN identifier values.
+ */
+export using can_id_filter = can_filter<u16>;
+
+/**
+ * @brief Filter accepting extended CAN message IDs
+ *
+ * Filters messages by single 29-bit extended CAN identifier values.
+ */
+export using can_id_ext_filter = can_filter<u32>;
+
+/**
+ * @brief Filter accepting standard CAN IDs using mask-based matching
+ *
+ * Filters messages by applying a bitwise mask to standard (11-bit) IDs.
+ */
+export using can_mask_filter = can_filter<can_mask>;
+
+/**
+ * @brief Filter accepting extended CAN IDs using mask-based matching
+ *
+ * Filters messages by applying a bitwise mask to extended (29-bit) IDs.
+ */
+export using can_mask_ext_filter = can_filter<can_mask_ext>;
+
+/**
+ * @brief Filter accepting standard CAN IDs within a range
+ *
+ * Filters messages by accepting those with standard (11-bit) IDs falling
+ * within a specified range.
+ */
+export using can_range_filter = can_filter<can_range>;
+
+/**
+ * @brief Filter accepting extended CAN IDs within a range
+ *
+ * Filters messages by accepting those with extended (29-bit) IDs falling
+ * within a specified range.
+ */
+export using can_range_ext_filter = can_filter<can_range_ext>;
 }  // namespace hal::inline v5

--- a/v5/modules/can.cppm
+++ b/v5/modules/can.cppm
@@ -244,31 +244,40 @@ private:
 };
 
 /**
- * @brief CAN Bus message reception hardware abstraction interface
+ * @brief Extension of can_transceiver with interrupt-driven RX notification.
  *
- * Implementations of this interface are NOT sharable across multiple device or
- * applications drivers. If shared, only the last handler set will be the one
- * that will execute on message reception.
+ * Extends the can_transceiver interface with the ability to suspend a coroutine
+ * until a new message is written into the receive buffer. Use this interface
+ * when the underlying hardware can signal RX activity via interrupt.
  *
- * Implementations of this interface allow interrupts to be fired when a new
- * message is received. If message filtering is enabled, then the callback will
- * only be for messages received through the filter.
+ * Drivers that cannot natively signal RX events should not implement this
+ * interface. Use the cursor-based polling API via `receive_buffer()` and
+ * `receive_cursor()` on the base `can_transceiver` interface instead.
  */
-export class can_interrupt
+export class awaitable_can_transceiver : public can_transceiver
 {
 public:
   /**
-   * @brief Wait for a new message reception event
+   * @brief Suspend until the next CAN message is received
    *
-   * @param p_context - async context for coroutine suspension and resumption.
-   * @return async::future<void> - completes when a message is received
+   * Multiple coroutines may concurrently await this function. All registered
+   * waiters are unblocked when the next message arrives in the receive buffer.
+   * If the implementation's internal waiter capacity is exceeded, the caller
+   * will block by sync until a slot becomes available. Starvation under this
+   * condition is possible depending on the scheduling algorithm in use;
+   * developers with strict fairness requirements should account for this when
+   * selecting or implementing a scheduler.
+   *
+   * @param p_context - async context for coroutine suspension and resumption
+   * @return async::future<void> - completes when a message has been written
+   *         into the receive buffer
    */
   async::future<void> on_receive(async::context& p_context)
   {
     return driver_on_receive(p_context);
   }
 
-  virtual ~can_interrupt() = default;
+  ~awaitable_can_transceiver() override = default;
 
 private:
   virtual async::future<void> driver_on_receive(async::context& p_context) = 0;

--- a/v5/modules/can.cppm
+++ b/v5/modules/can.cppm
@@ -1,0 +1,703 @@
+// Copyright 2024 - 2025 Khalil Estell and the libhal contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module;
+
+#include <array>
+#include <optional>
+#include <span>
+
+export module hal:can;
+
+import :units;
+
+namespace hal::inline v5 {
+/**
+ * @brief A standard CAN message
+ *
+ */
+export struct can_message
+{
+  /**
+   * @brief Memory containing a standard or extended CAN ID
+   *
+   * Bits 29 to 31 are reserved and should only be set to 0s.
+   *
+   */
+  hal::u32 id = 0;
+
+  /**
+   * @brief Determines if this message ID is an extended ID or not
+   *
+   * When set to `true`, will treat all 29 bits of the ID of the message.
+   * When set to `false`, then this is a standard can message and only the first
+   * 11 bits will be used for the message ID.
+   */
+  bool extended = false;
+
+  /**
+   * @brief Determines if this message is a remote request
+   *
+   * In general, using remote request frames are bad practice and cause issues
+   * on the CAN BUS.
+   *
+   */
+  bool remote_request = false;
+
+  /**
+   * @brief The number of valid elements in the payload
+   *
+   * Can be between 0 and 8. A length value above 8 should be considered
+   * invalid and can be discarded.
+   */
+  u8 length = 0;
+
+  /**
+   * @brief Reserved aligning byte allocated to 4 for potential further changes
+   *
+   * Never set this value to anything other than 0.
+   */
+  u8 reserved0 = 0;
+
+  /**
+   * @brief Message data contents
+   *
+   */
+  std::array<hal::byte, 8> payload{};
+
+  /**
+   * @brief Compares a can message to itself to verify if they are the same
+   *
+   * NOTE: This comparison only checks the valid payload bytes in the payload
+   * based on the length. If the length is 1 and the second byte in the payload
+   * between messages do not match, then the can messages are still considered
+   * equal.
+   *
+   * @param p_other - the other can_message to compare against
+   * @return true - the two can messages are identical
+   * @return false - the two can messages are not identical
+   */
+  constexpr bool operator==(can_message const& p_other) const
+  {
+    if (length != p_other.length) {
+      return false;
+    }
+    if (id != p_other.id) {
+      return false;
+    }
+    if (remote_request != p_other.remote_request) {
+      return false;
+    }
+    if (extended != p_other.extended) {
+      return false;
+    }
+    for (usize i = 0; i < length; i++) {
+      if (payload[i] != p_other.payload[i]) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+};
+
+constexpr auto can_message_size = sizeof(can_message);
+static_assert(can_message_size == 16, "sizeof(hal::can_message) != 16 Bytes");
+
+/**
+ * @brief Controller Area Network (CAN bus) hardware abstraction interface with
+ * message buffering.
+ *
+ * Implementations of this interface are sharable across multiple applications
+ * and device drivers.
+ *
+ * Buffered can provides easy access to all can messages received by the CAN bus
+ * allowing multiple device drivers to use the same buffered can for their
+ * operations.
+ *
+ * This interface does not provide APIs for CAN message hardware filtering. The
+ * hardware implementation for CAN message filter varies wildly across devices
+ * and thus a common API is infeasible. So we rely on the concrete classes, the
+ * implementations of this interface to provide APIs for setting the CAN filter
+ * for the specific hardware. Hardware filtering is a best effort with the
+ * resources available. It is often not possible to filter every possible ID in
+ * hardware that your application is interested in. Thus, must expect that the
+ * CAN message receive buffer.
+ *
+ * All implementations MUST allow the user to supply their own message buffer of
+ * arbitrary size. This allows a developer the ability to tailored the buffer
+ * size to the needs of the application.
+ *
+ * All CAN messages that pass through the hardware filter will be added to the,
+ * message circular buffer.
+ */
+export class can_transceiver
+{
+public:
+  /**
+   * @return the device's operating baud rate in hertz
+   */
+  async::future<u32> baud_rate(async::context& p_context)
+  {
+    return driver_baud_rate(p_context);
+  }
+
+  /**
+   * @brief Send a can message over the can network
+   *
+   * @param p_message - a message to be sent over the can network
+   * @throws hal::operation_not_permitted - or a derivative of this class, if
+   *         the can device has entered the "bus-off" state. This can happen if
+   *         a critical fault in the bus has occurred. A call to `bus_on()`
+   *         will need to be issued to attempt to talk on the bus again. See
+   *         `bus_on()` for more details.
+   *
+   */
+  async::future<void> send(async::context& p_context,
+                           can_message const& p_message)
+  {
+    driver_send(p_message);
+  }
+
+  /**
+   * @brief Returns this CAN driver's message receive buffer
+   *
+   * Use this along with the receive_cursor() in order to determine if new data
+   * has been read into the receive buffer. See the docs for `receive_cursor()`
+   * for more details.
+   *
+   * This API will work even if the CAN peripheral is "bus-off".
+   *
+   * @return std::span<message const> - constant span to the message receive
+   *         buffer used by this driver. Assume the lifetime of the buffer is
+   *         the same as the class's lifetime. When the memory of the owning
+   *         object is invalidated, so is this span. Calling `size()` on the
+   *         span will always return a value of at least 1.
+   */
+  std::span<can_message const> receive_buffer()
+  {
+    return driver_receive_buffer();
+  }
+
+  /**
+   * @brief Returns the current write position of the circular receive buffer
+   *
+   * Receive head represents the position where the next message will be written
+   * in the receive buffer. This position advances as new messages arrives. To
+   * determine how much new data has arrived, store the previous head position
+   * and compare it with the current head position, accounting for buffer
+   * wraparound.
+   *
+   * The cursor value will ALWAYS follow this equation:
+   *
+   *          0 <= cursor && cursor < receive_buffer().size()
+   *
+   * Thus this expression is always a valid memory access but may not return
+   * useful information:
+   *
+   *         can.receive_buffer()[ can.cursor() ];
+   *
+   * Example:
+   *
+   *   auto old_head = port.receive_cursor();
+   *   // ... wait for new data ...
+   *   auto new_head = port.receive_cursor();
+   *   // Account for circular wraparound when calculating messages received
+   *   auto buffer_size = port.receive_buffer().size();
+   *   auto messages_received =
+   *          (new_head + buffer_size - old_head) % buffer_size;
+   *
+   * The data between your last saved position and the current head position
+   * represents the newly received messages. When reading the data, remember
+   * that it may wrap around from the end of the buffer back to the beginning.
+   *
+   * This function will not change if the state of the system is "bus-off".
+   *
+   * @return usize - position of the write cursor for the circular buffer.
+   */
+  usize receive_cursor()
+  {
+    return driver_receive_cursor();
+  }
+
+  virtual ~can_transceiver() = default;
+
+private:
+  virtual u32 driver_baud_rate() = 0;
+  virtual void driver_send(can_message const& p_message) = 0;
+  virtual std::span<can_message const> driver_receive_buffer() = 0;
+  virtual usize driver_receive_cursor() = 0;
+};
+
+/**
+ * @brief CAN Bus message reception hardware abstraction interface
+ *
+ * Implementations of this interface are NOT sharable across multiple device or
+ * applications drivers. If shared, only the last handler set will be the one
+ * that will execute on message reception.
+ *
+ * Implementations of this interface allow interrupts to be fired when a new
+ * message is received. If message filtering is enabled, then the callback will
+ * only be for messages received through the filter.
+ */
+class can_interrupt
+{
+public:
+  /**
+   * @brief Set a callback to occur when a new message has been received
+   *
+   */
+  async::future<void> on_receive(async::context& p_context)
+  {
+    driver_on_receive(p_context);
+  }
+
+  virtual ~can_interrupt() = default;
+
+private:
+  virtual async::future<void> driver_on_receive(async::context& p_context) = 0;
+};
+
+/**
+ * @brief CAN Bus configuration & control hardware abstraction interface
+ *
+ * Implementations of this interface are NOT sharable across multiple device or
+ * applications drivers. Generally a single application or process should
+ * control the CAN bus.
+ *
+ */
+class can_bus_manager
+{
+public:
+  /**
+   * @brief Message acceptance mode for the can bus
+   *
+   */
+  enum class accept : u8
+  {
+    /// Accept no messages over the bus
+    none,
+    /// Accept all messages, ignore all filters
+    all,
+    /// Only accept messages that pass through filters. If no filters have been
+    /// setup, then no messages will be received.
+    filtered,
+  };
+
+  /**
+   * @brief Set the can bus baud rate
+   *
+   * The baud rate is the communication rate of the can bus. At a baud rate of
+   * 1MHz, each bit has a width of 1us. At 100kHz, each bit has a width of 10us.
+   * The developer must ensure that the baud rate is set to the correct
+   * communication rate for all devices on the bus. If all other devices on the
+   * bus communicate at 100kHz then all other devices on the bus MUST
+   * communicate at 100kHz.
+   *
+   * This API should be called before passing a `hal::can_transceiver`,
+   * corrsponding to this can bus to a device driver for usage.
+   *
+   * @param p_hertz - baud rate in hertz
+   * @throws hal::operation_not_supported if the baud rate is above or below
+   * what the device can support.
+   */
+  async::future<void> baud_rate(async::context& p_context, hal::u32 p_hertz)
+  {
+    driver_baud_rate(p_context, p_hertz);
+  }
+
+  /**
+   * @brief Set the filter mode for the can bus
+   *
+   * @param p_accept - defines the set of messages that will be accepted. See
+   * the `accept` enum class for details about each option and what they do.
+   */
+  async::future<void> filter_mode(async::context& p_context, accept p_accept)
+  {
+    driver_filter_mode(p_context, p_accept);
+  }
+
+  /**
+   * @brief Set a callback for when the CAN device goes bus-off
+   *
+   * The BUS-OFF state for CAN is denoted by the occurrence of too many
+   * transmission errors (TEC > 255) causing the CAN controller to disconnect
+   * from the bus to prevent further network disruption. During bus-off,
+   * the node cannot transmit or receive any messages.
+   *
+   * On construction of the can driver, the default callback for the bus-off
+   * event is to do nothing. The `send()` API throw the
+   * `hal::operation_not_permitted` exception and the `receive_cursor()` API
+   * will not update.
+   *
+   * Care should be taken when writing the callback, as it will most likely be
+   * executed in an interrupt context.
+   */
+  async::future<void> on_bus_off(async::context& p_context)
+  {
+    driver_on_bus_off(p_context);
+  }
+
+  /**
+   * @brief Transition the CAN device from "bus-off" to "bus-on"
+   *
+   * Calling this function when the device is already "bus-on" will have no
+   * effect. This function is not necessary to call after creating the CAN
+   * driver as the driver should already be "bus-on" on creation.
+   *
+   * Can devices have two counters to determine system health. These two
+   * counters are the "transmit error counter" and the "receive error counter".
+   * Transmission errors can occur when the device attempts to communicate on
+   * the bus and either does not get an acknowledge or sees an unexpected or
+   * erroneous signal on the bus during its own transmission. When transmission
+   * errors reach 255 counts, the device will go into the "bus-off" state.
+   *
+   * In the "bus-off" state, the CAN peripheral can no longer communicate on the
+   * bus. Any calls to `send()` will throw the error
+   * `hal::operation_not_permitted`. If this occurs, this function must be
+   * called to re-enable bus communication.
+   *
+   */
+  async::future<void> bus_on(async::context& p_context)
+  {
+    driver_bus_on(p_context);
+  }
+
+  virtual ~can_bus_manager() = default;
+
+private:
+  virtual async::future<void> driver_baud_rate(async::context& p_context,
+                                               hal::u32 p_hertz) = 0;
+  virtual async::future<void> driver_filter_mode(async::context& p_context,
+                                                 accept p_accept) = 0;
+  virtual async::future<void> driver_on_bus_off(async::context& p_context) = 0;
+  virtual async::future<void> driver_bus_on(async::context& p_context) = 0;
+};
+
+/**
+ * @brief CAN message ID filter hardware abstraction interface
+ *
+ * On construction, implementations acquire/reserve resources for filtering the
+ * message passed to the `allow()` API. On destruction, those resources should
+ * be freed such that another can_identifier_filter can claim them. In general,
+ * filters of all sorts are limited in the number and type of filters they
+ * support.
+ */
+class can_identifier_filter
+{
+public:
+  /**
+   * @brief Allow messages with this identifier to pass the can bus filter
+   *
+   * This filter does not distinguish between remote request frames and data
+   * frames. Frames of either type will be allowed so long as the message
+   * identifier matches.
+   *
+   * @param p_id - Allow messages with this ID through to the can message
+   * filter. To stop allowing messages from this filter, set this parameter to
+   * `std::nullopt`.
+   */
+  void allow(std::optional<u16> p_id)
+  {
+    driver_allow(p_id);
+  }
+
+  virtual ~can_identifier_filter() = default;
+
+private:
+  virtual void driver_allow(std::optional<u16> p_id) = 0;
+};
+
+/**
+ * @brief CAN message extended ID filter hardware abstraction interface
+ *
+ * On construction, implementations acquire/reserve resources for filtering the
+ * message passed to the `allow()` API. On destruction, those resources should
+ * be freed such that another can_identifier_filter can claim them. In general,
+ * filters of all sorts are limited in the number and type of filters they
+ * support.
+ */
+class can_extended_identifier_filter
+{
+public:
+  /**
+   * @brief Allow messages with this identifier to pass the can bus filter
+   *
+   * This filter does not distinguish between remote request frames and data
+   * frames. Frames of either type will be allowed so long as the message
+   * identifier matches.
+   *
+   * @param p_id - Allow messages with this ID through to the can message
+   * filter. To stop allowing messages from this filter, set this parameter to
+   * `std::nullopt`.
+   */
+  void allow(std::optional<u32> p_id)
+  {
+    driver_allow(p_id);
+  }
+
+  virtual ~can_extended_identifier_filter() = default;
+
+private:
+  virtual void driver_allow(std::optional<u32> p_id) = 0;
+};
+
+/**
+ * @brief CAN message mask filter hardware abstraction interface
+ *
+ * On construction, implementations acquire/reserve resources for filtering the
+ * message passed to the `allow()` API. On destruction, those resources should
+ * be freed such that another can_identifier_filter can claim them. In general,
+ * filters of all sorts are limited in the number and type of filters they
+ * support.
+ */
+class can_mask_filter
+{
+public:
+  /**
+   * @brief Mask filter
+   *
+   * The following equation must be true in order for the message to pass the
+   * can bus filter.
+   *
+   *     received_message_id & mask == id & mask
+   */
+  struct pair
+  {
+    /**
+     * @brief Specifies an ID to match against
+     *
+     */
+    u16 id = 0;
+    /**
+     * @brief Specifies which bits of the ID to consider.
+     *
+     * For example, a mask of 0x7FF would match all bits in a 11-bit ID since
+     * all 11 bits are set. A mask of 0x7F0, would allow messages with the most
+     * significant 7 bits of the ID and the lower 4 bits can be any value.
+     *
+     */
+    u16 mask = 0;
+    /**
+     * @brief Enables default comparison
+     *
+     */
+    constexpr bool operator<=>(pair const&) const = default;
+  };
+
+  /**
+   * @brief Allow messages that correspond to this mask pass the can bus filter
+   *
+   * This filter does not distinguish between remote request frames and data
+   * frames. Frames of either type will be allowed so long as the message
+   * identifier matches.
+   *
+   * @param p_filter_pair - mask filter used to filter incoming messages. To
+   * stop allowing messages from this filter, set this parameter to
+   * `std::nullopt`.
+   */
+  void allow(std::optional<pair> p_filter_pair)
+  {
+    driver_allow(p_filter_pair);
+  }
+
+  virtual ~can_mask_filter() = default;
+
+private:
+  virtual void driver_allow(std::optional<pair> p_filter_pair) = 0;
+};
+
+/**
+ * @brief CAN message extended mask filter hardware abstraction interface
+ *
+ * On construction, implementations acquire/reserve resources for filtering the
+ * message passed to the `allow()` API. On destruction, those resources should
+ * be freed such that another can_identifier_filter can claim them. In general,
+ * filters of all sorts are limited in the number and type of filters they
+ * support.
+ */
+class can_extended_mask_filter
+{
+public:
+  /**
+   * @brief Extended mask filter
+   *
+   * The following equation must be true in order for the message to pass the
+   * can bus filter.
+   *
+   *     received_message_id & mask == id & mask
+   */
+  struct pair
+  {
+    /**
+     * @brief Specifies an ID to match against
+     *
+     */
+    u32 id = 0;
+    /**
+     * @brief Specifies which bits of the ID to consider.
+     *
+     * For example, a mask of 0x1FFFFFFF would match all bits in a 29-bit ID
+     * since all 29 bits are set. A mask of 0x1FFFFFF0, would allow messages
+     * with the most significant 25 bits of the ID and the lower 4 bits can be
+     * any value.
+     *
+     */
+    u32 mask = 0;
+    /**
+     * @brief Enables default comparison
+     *
+     */
+    constexpr bool operator<=>(pair const&) const = default;
+  };
+
+  /**
+   * @brief Set the allowed messages through a mask filter.
+   *
+   * This filter does not distinguish between remote request frames and data
+   * frames. Frames of either type will be allowed so long as the message
+   * identifier matches.
+   *
+   * This filter can be used to both standard and extended identifier frames.
+   * Implements should disregard the IDE bit if their platforms support
+   * filtering based on this bit.
+   *
+   * @param p_filter_pair - mask filter used to filter incoming messages. Set
+   * this to `std::nullopt` to disengage this filter.
+   */
+  void allow(std::optional<pair> p_filter_pair)
+  {
+    driver_allow(p_filter_pair);
+  }
+
+  virtual ~can_extended_mask_filter() = default;
+
+private:
+  virtual void driver_allow(std::optional<pair> p_filter_pair) = 0;
+};
+
+/**
+ * @brief CAN message range filter hardware abstraction interface
+ *
+ * On construction, implementations acquire/reserve resources for filtering the
+ * message passed to the `allow()` API. On destruction, those resources should
+ * be freed such that another can_identifier_filter can claim them. In general,
+ * filters of all sorts are limited in the number and type of filters they
+ * support.
+ */
+class can_range_filter
+{
+public:
+  /**
+   * @brief filter pair information
+   *
+   * id_1 and id_2 constitute a range of allowed IDs. They do NOT need to be
+   * ordered relative to each other. Meaning id_1 < id_2 is not required or
+   * necessary. Setting id_1 and id_2 to the same value allowed and will act
+   * like can_identifier_mask.
+   */
+  struct pair
+  {
+    /**
+     * @brief Specifies one end of the id range bounds.
+     *
+     */
+    u16 id_1 = 0;
+    /**
+     * @brief Specifies the other end of the id range bounds
+     *
+     */
+    u16 id_2 = 0;
+    /**
+     * @brief Enables default comparison
+     *
+     */
+    constexpr bool operator<=>(pair const&) const = default;
+  };
+
+  /**
+   * @brief Allow messages within this id range to pass the can bus filter
+   *
+   * @param p_filter_pair - allow this range of IDs through the can filter. To
+   * stop allowing messages from this filter, set this parameter to
+   * `std::nullopt`.
+   */
+  void allow(std::optional<pair> p_filter_pair)
+  {
+    driver_allow(p_filter_pair);
+  }
+
+  virtual ~can_range_filter() = default;
+
+private:
+  virtual void driver_allow(std::optional<pair> p_filter_pair) = 0;
+};
+
+/**
+ * @brief CAN message extended range filter hardware abstraction interface
+ *
+ * On construction, implementations acquire/reserve resources for filtering the
+ * message passed to the `allow()` API. On destruction, those resources should
+ * be freed such that another can_identifier_filter can claim them. In general,
+ * filters of all sorts are limited in the number and type of filters they
+ * support.
+ */
+class can_extended_range_filter
+{
+public:
+  /**
+   * @brief Range filter
+   *
+   * id_1 and id_2 constitute a range of allowed IDs. They do NOT need to be
+   * ordered relative to each other. Meaning id_1 < id_2 is not required or
+   * necessary. Setting id_1 and id_2 to the same value allowed and will act
+   * like can_identifier_mask.
+   */
+  struct pair
+  {
+    /**
+     * @brief Specifies one end of the id range bounds.
+     *
+     */
+    u32 id_1 = 0;
+    /**
+     * @brief Specifies the other end of the id range bounds
+     *
+     */
+    u32 id_2 = 0;
+    /**
+     * @brief Enables default comparison
+     *
+     */
+    constexpr bool operator<=>(pair const&) const = default;
+  };
+
+  /**
+   * @brief Set the allowed messages through a range filter.
+   *
+   * @param p_filter_pair - allow this range of IDs through the can filter. To
+   * stop allowing messages from this filter, set this parameter to
+   * `std::nullopt`.
+   */
+  void allow(std::optional<pair> p_filter_pair)
+  {
+    driver_allow(p_filter_pair);
+  }
+
+  virtual ~can_extended_range_filter() = default;
+
+private:
+  virtual void driver_allow(std::optional<pair> p_filter_pair) = 0;
+};
+}  // namespace hal::inline v5

--- a/v5/modules/can.cppm
+++ b/v5/modules/can.cppm
@@ -20,6 +20,7 @@ module;
 
 export module hal:can;
 
+export import async_context;
 import :units;
 
 namespace hal::inline v5 {
@@ -156,6 +157,7 @@ public:
   /**
    * @brief Send a can message over the can network
    *
+   * @param p_context - async context for coroutine suspension and resumption.
    * @param p_message - a message to be sent over the can network
    * @throws hal::operation_not_permitted - or a derivative of this class, if
    *         the can device has entered the "bus-off" state. This can happen if
@@ -167,7 +169,7 @@ public:
   async::future<void> send(async::context& p_context,
                            can_message const& p_message)
   {
-    driver_send(p_message);
+    return driver_send(p_context, p_message);
   }
 
   /**
@@ -234,8 +236,9 @@ public:
   virtual ~can_transceiver() = default;
 
 private:
-  virtual u32 driver_baud_rate() = 0;
-  virtual void driver_send(can_message const& p_message) = 0;
+  virtual async::future<u32> driver_baud_rate(async::context& p_context) = 0;
+  virtual async::future<void> driver_send(async::context& p_context,
+                                          can_message const& p_message) = 0;
   virtual std::span<can_message const> driver_receive_buffer() = 0;
   virtual usize driver_receive_cursor() = 0;
 };
@@ -257,10 +260,11 @@ public:
   /**
    * @brief Set a callback to occur when a new message has been received
    *
+   * @param p_context - async context for coroutine suspension and resumption.
    */
   async::future<void> on_receive(async::context& p_context)
   {
-    driver_on_receive(p_context);
+    return driver_on_receive(p_context);
   }
 
   virtual ~can_interrupt() = default;
@@ -308,24 +312,26 @@ public:
    * This API should be called before passing a `hal::can_transceiver`,
    * corrsponding to this can bus to a device driver for usage.
    *
+   * @param p_context - async context for coroutine suspension and resumption.
    * @param p_hertz - baud rate in hertz
    * @throws hal::operation_not_supported if the baud rate is above or below
    * what the device can support.
    */
   async::future<void> baud_rate(async::context& p_context, hal::u32 p_hertz)
   {
-    driver_baud_rate(p_context, p_hertz);
+    return driver_baud_rate(p_context, p_hertz);
   }
 
   /**
    * @brief Set the filter mode for the can bus
    *
+   * @param p_context - async context for coroutine suspension and resumption.
    * @param p_accept - defines the set of messages that will be accepted. See
    * the `accept` enum class for details about each option and what they do.
    */
   async::future<void> filter_mode(async::context& p_context, accept p_accept)
   {
-    driver_filter_mode(p_context, p_accept);
+    return driver_filter_mode(p_context, p_accept);
   }
 
   /**
@@ -343,10 +349,12 @@ public:
    *
    * Care should be taken when writing the callback, as it will most likely be
    * executed in an interrupt context.
+   *
+   * @param p_context - async context for coroutine suspension and resumption.
    */
   async::future<void> on_bus_off(async::context& p_context)
   {
-    driver_on_bus_off(p_context);
+    return driver_on_bus_off(p_context);
   }
 
   /**
@@ -368,10 +376,11 @@ public:
    * `hal::operation_not_permitted`. If this occurs, this function must be
    * called to re-enable bus communication.
    *
+   * @param p_context - async context for coroutine suspension and resumption.
    */
   async::future<void> bus_on(async::context& p_context)
   {
-    driver_bus_on(p_context);
+    return driver_bus_on(p_context);
   }
 
   virtual ~can_bus_manager() = default;
@@ -404,19 +413,21 @@ public:
    * frames. Frames of either type will be allowed so long as the message
    * identifier matches.
    *
+   * @param p_context - async context for coroutine suspension and resumption.
    * @param p_id - Allow messages with this ID through to the can message
    * filter. To stop allowing messages from this filter, set this parameter to
    * `std::nullopt`.
    */
-  void allow(std::optional<u16> p_id)
+  async::future<void> allow(async::context& p_context, std::optional<u16> p_id)
   {
-    driver_allow(p_id);
+    return driver_allow(p_context, p_id);
   }
 
   virtual ~can_identifier_filter() = default;
 
 private:
-  virtual void driver_allow(std::optional<u16> p_id) = 0;
+  virtual async::future<void> driver_allow(async::context& p_context,
+                                           std::optional<u16> p_id) = 0;
 };
 
 /**
@@ -438,19 +449,21 @@ public:
    * frames. Frames of either type will be allowed so long as the message
    * identifier matches.
    *
+   * @param p_context - async context for coroutine suspension and resumption.
    * @param p_id - Allow messages with this ID through to the can message
    * filter. To stop allowing messages from this filter, set this parameter to
    * `std::nullopt`.
    */
-  void allow(std::optional<u32> p_id)
+  async::future<void> allow(async::context& p_context, std::optional<u32> p_id)
   {
-    driver_allow(p_id);
+    return driver_allow(p_context, p_id);
   }
 
   virtual ~can_extended_identifier_filter() = default;
 
 private:
-  virtual void driver_allow(std::optional<u32> p_id) = 0;
+  virtual async::future<void> driver_allow(async::context& p_context,
+                                           std::optional<u32> p_id) = 0;
 };
 
 /**
@@ -503,19 +516,23 @@ public:
    * frames. Frames of either type will be allowed so long as the message
    * identifier matches.
    *
+   * @param p_context - async context for coroutine suspension and resumption.
    * @param p_filter_pair - mask filter used to filter incoming messages. To
    * stop allowing messages from this filter, set this parameter to
    * `std::nullopt`.
    */
-  void allow(std::optional<pair> p_filter_pair)
+  async::future<void> allow(async::context& p_context,
+                            std::optional<pair> p_filter_pair)
   {
-    driver_allow(p_filter_pair);
+    return driver_allow(p_context, p_filter_pair);
   }
 
   virtual ~can_mask_filter() = default;
 
 private:
-  virtual void driver_allow(std::optional<pair> p_filter_pair) = 0;
+  virtual async::future<void> driver_allow(
+    async::context& p_context,
+    std::optional<pair> p_filter_pair) = 0;
 };
 
 /**
@@ -573,18 +590,22 @@ public:
    * Implements should disregard the IDE bit if their platforms support
    * filtering based on this bit.
    *
+   * @param p_context - async context for coroutine suspension and resumption.
    * @param p_filter_pair - mask filter used to filter incoming messages. Set
    * this to `std::nullopt` to disengage this filter.
    */
-  void allow(std::optional<pair> p_filter_pair)
+  async::future<void> allow(async::context& p_context,
+                            std::optional<pair> p_filter_pair)
   {
-    driver_allow(p_filter_pair);
+    return driver_allow(p_context, p_filter_pair);
   }
 
   virtual ~can_extended_mask_filter() = default;
 
 private:
-  virtual void driver_allow(std::optional<pair> p_filter_pair) = 0;
+  virtual async::future<void> driver_allow(
+    async::context& p_context,
+    std::optional<pair> p_filter_pair) = 0;
 };
 
 /**
@@ -629,19 +650,23 @@ public:
   /**
    * @brief Allow messages within this id range to pass the can bus filter
    *
+   * @param p_context - async context for coroutine suspension and resumption.
    * @param p_filter_pair - allow this range of IDs through the can filter. To
    * stop allowing messages from this filter, set this parameter to
    * `std::nullopt`.
    */
-  void allow(std::optional<pair> p_filter_pair)
+  async::future<void> allow(async::context& p_context,
+                            std::optional<pair> p_filter_pair)
   {
-    driver_allow(p_filter_pair);
+    return driver_allow(p_context, p_filter_pair);
   }
 
   virtual ~can_range_filter() = default;
 
 private:
-  virtual void driver_allow(std::optional<pair> p_filter_pair) = 0;
+  virtual async::future<void> driver_allow(
+    async::context& p_context,
+    std::optional<pair> p_filter_pair) = 0;
 };
 
 /**
@@ -686,18 +711,22 @@ public:
   /**
    * @brief Set the allowed messages through a range filter.
    *
+   * @param p_context - async context for coroutine suspension and resumption.
    * @param p_filter_pair - allow this range of IDs through the can filter. To
    * stop allowing messages from this filter, set this parameter to
    * `std::nullopt`.
    */
-  void allow(std::optional<pair> p_filter_pair)
+  async::future<void> allow(async::context& p_context,
+                            std::optional<pair> p_filter_pair)
   {
-    driver_allow(p_filter_pair);
+    return driver_allow(p_context, p_filter_pair);
   }
 
   virtual ~can_extended_range_filter() = default;
 
 private:
-  virtual void driver_allow(std::optional<pair> p_filter_pair) = 0;
+  virtual async::future<void> driver_allow(
+    async::context& p_context,
+    std::optional<pair> p_filter_pair) = 0;
 };
 }  // namespace hal::inline v5

--- a/v5/modules/hal.cppm
+++ b/v5/modules/hal.cppm
@@ -19,6 +19,7 @@ export import :scatter_span;
 export import :error;
 
 export import :analog;
+export import :can;
 export import :pwm;
 export import :gpio;
 export import :sensors;

--- a/v5/modules/serial.cppm
+++ b/v5/modules/serial.cppm
@@ -255,7 +255,7 @@ public:
     return driver_wait_for(p_context, p_event);
   }
 
-  virtual ~awaitable_serial() = default;
+  ~awaitable_serial() override = default;
 
 private:
   virtual async::future<void> driver_wait_for(async::context& p_context,

--- a/v5/tests/can.test.cpp
+++ b/v5/tests/can.test.cpp
@@ -1,0 +1,541 @@
+// Copyright 2026 Khalil Estell and the libhal contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <array>
+#include <coroutine>
+#include <memory_resource>
+#include <optional>
+
+#include <boost/ut.hpp>
+
+import hal;
+import async_context;
+
+using namespace mp_units;
+using namespace mp_units::si::unit_symbols;
+
+namespace {
+class test_can_transceiver : public hal::can_transceiver
+{
+public:
+  hal::can_message last_sent_message{};
+  std::array<hal::can_message, 8> rx_buffer{};
+  hal::usize rx_cursor{ 0 };
+  hal::hertz baud_rate_hz{ 500'000 * Hz };
+
+  ~test_can_transceiver() override = default;
+
+private:
+  async::future<hal::hertz> driver_baud_rate(async::context&) override
+  {
+    return baud_rate_hz;
+  }
+
+  async::future<void> driver_send(async::context&,
+                                  hal::can_message const& p_message) override
+  {
+    last_sent_message = p_message;
+    return {};
+  }
+
+  hal::circular_span<hal::can_message const> driver_receive_buffer() override
+  {
+    return rx_buffer;
+  }
+
+  hal::usize driver_receive_cursor() override
+  {
+    return rx_cursor;
+  }
+};
+
+class test_can_bus_manager : public hal::can_bus_manager
+{
+public:
+  hal::u32 last_baud_rate{ 0 };
+  hal::can_message_acceptance last_filter_mode{};
+  bool on_bus_off_called{ false };
+  bool bus_on_called{ false };
+
+  ~test_can_bus_manager() override = default;
+
+private:
+  async::future<void> driver_baud_rate(async::context&,
+                                       hal::u32 p_hertz) override
+  {
+    last_baud_rate = p_hertz;
+    return {};
+  }
+
+  async::future<void> driver_filter_mode(
+    async::context&,
+    hal::can_message_acceptance p_accept) override
+  {
+    last_filter_mode = p_accept;
+    return {};
+  }
+
+  async::future<void> driver_on_bus_off(async::context&) override
+  {
+    on_bus_off_called = true;
+    return {};
+  }
+
+  async::future<void> driver_bus_on(async::context&) override
+  {
+    bus_on_called = true;
+    return {};
+  }
+};
+
+class test_can_interrupt : public hal::can_interrupt
+{
+public:
+  bool on_receive_called{ false };
+
+  ~test_can_interrupt() override = default;
+
+private:
+  async::future<void> driver_on_receive(async::context&) override
+  {
+    on_receive_called = true;
+    return {};
+  }
+};
+
+template<typename Allowed>
+class test_can_filter : public hal::can_filter<Allowed>
+{
+public:
+  std::optional<Allowed> last_allowed{ std::nullopt };
+
+  ~test_can_filter() override = default;
+
+private:
+  async::future<void> driver_allow(async::context&,
+                                   std::optional<Allowed> p_allowed) override
+  {
+    last_allowed = p_allowed;
+    return {};
+  }
+};
+
+void can_message_equality_test() noexcept
+{
+  using namespace boost::ut;
+
+  "can_message equality with identical messages"_test = [&]() {
+    hal::can_message a{
+      .id = 0x123,
+      .extended = false,
+      .remote_request = false,
+      .length = 3,
+      .payload = { hal::byte{ 0x01 }, hal::byte{ 0x02 }, hal::byte{ 0x03 } },
+    };
+    hal::can_message b = a;
+
+    expect(a == b);
+  };
+
+  "can_message inequality when IDs differ"_test = [&]() {
+    hal::can_message a{ .id = 0x100, .length = 1 };
+    hal::can_message b{ .id = 0x200, .length = 1 };
+
+    expect(!(a == b));
+  };
+
+  "can_message inequality when lengths differ"_test = [&]() {
+    hal::can_message a{ .id = 0x100, .length = 1 };
+    hal::can_message b{ .id = 0x100, .length = 2 };
+
+    expect(!(a == b));
+  };
+
+  "can_message inequality when payload bytes within length differ"_test =
+    [&]() {
+      hal::can_message a{
+        .id = 0x100,
+        .length = 2,
+        .payload = { hal::byte{ 0xAA }, hal::byte{ 0xBB } },
+      };
+      hal::can_message b{
+        .id = 0x100,
+        .length = 2,
+        .payload = { hal::byte{ 0xAA }, hal::byte{ 0xCC } },
+      };
+
+      expect(!(a == b));
+    };
+
+  "can_message equality ignores payload bytes beyond length"_test = [&]() {
+    hal::can_message a{
+      .id = 0x100,
+      .length = 1,
+      .payload = { hal::byte{ 0xAA }, hal::byte{ 0xFF } },
+    };
+    hal::can_message b{
+      .id = 0x100,
+      .length = 1,
+      .payload = { hal::byte{ 0xAA }, hal::byte{ 0x00 } },
+    };
+
+    expect(a == b);
+  };
+
+  "can_message inequality when extended flag differs"_test = [&]() {
+    hal::can_message a{ .id = 0x100, .extended = false, .length = 0 };
+    hal::can_message b{ .id = 0x100, .extended = true, .length = 0 };
+
+    expect(!(a == b));
+  };
+
+  "can_message inequality when remote_request flag differs"_test = [&]() {
+    hal::can_message a{ .id = 0x100, .remote_request = false, .length = 0 };
+    hal::can_message b{ .id = 0x100, .remote_request = true, .length = 0 };
+
+    expect(!(a == b));
+  };
+
+  "can_message equality with zero-length payload"_test = [&]() {
+    hal::can_message a{ .id = 0x42, .length = 0 };
+    hal::can_message b{ .id = 0x42, .length = 0 };
+
+    expect(a == b);
+  };
+
+  "can_message equality with extended ID"_test = [&]() {
+    hal::can_message a{
+      .id = 0x1FFFFFFF,
+      .extended = true,
+      .length = 2,
+      .payload = { hal::byte{ 0xDE }, hal::byte{ 0xAD } },
+    };
+    hal::can_message b = a;
+
+    expect(a == b);
+  };
+}
+
+void can_transceiver_baud_rate_test() noexcept
+{
+  using namespace boost::ut;
+
+  "baud_rate() returns configured value"_test = [&]() {
+    async::inplace_context<1024> ctx;
+    test_can_transceiver test;
+    test.baud_rate_hz = 1'000'000 * Hz;
+
+    auto result = test.baud_rate(ctx);
+
+    expect((1'000'000 * Hz) == result.value());
+  };
+
+  "baud_rate() returns default value"_test = [&]() {
+    async::inplace_context<1024> ctx;
+    test_can_transceiver test;
+
+    auto result = test.baud_rate(ctx);
+
+    expect((500'000 * Hz) == result.value());
+  };
+}
+
+void can_transceiver_send_test() noexcept
+{
+  using namespace boost::ut;
+
+  "send() passes message to driver"_test = [&]() {
+    async::inplace_context<1024> ctx;
+    test_can_transceiver test;
+    hal::can_message expected{
+      .id = 0x123,
+      .extended = false,
+      .remote_request = false,
+      .length = 2,
+      .payload = { hal::byte{ 0xAB }, hal::byte{ 0xCD } },
+    };
+
+    test.send(ctx, expected);
+
+    expect(expected == test.last_sent_message);
+  };
+
+  "send() with extended message"_test = [&]() {
+    async::inplace_context<1024> ctx;
+    test_can_transceiver test;
+    hal::can_message expected{
+      .id = 0x1FFFFFFF,
+      .extended = true,
+      .length = 1,
+      .payload = { hal::byte{ 0xFF } },
+    };
+
+    test.send(ctx, expected);
+
+    expect(expected == test.last_sent_message);
+  };
+
+  "send() with zero-length message"_test = [&]() {
+    async::inplace_context<1024> ctx;
+    test_can_transceiver test;
+    hal::can_message expected{ .id = 0x200, .length = 0 };
+
+    test.send(ctx, expected);
+
+    expect(expected == test.last_sent_message);
+  };
+}
+
+void can_transceiver_receive_buffer_test() noexcept
+{
+  using namespace boost::ut;
+
+  "receive_buffer() returns driver's buffer"_test = [&]() {
+    test_can_transceiver test;
+    test.rx_buffer[0].id = 0x111;
+    test.rx_buffer[1].id = 0x222;
+
+    auto buf = test.receive_buffer();
+
+    expect(that % test.rx_buffer.size() == buf.size());
+    expect(that % 0x111u == buf[0].id);
+    expect(that % 0x222u == buf[1].id);
+  };
+
+  "receive_buffer() size is at least 1"_test = [&]() {
+    test_can_transceiver test;
+
+    auto buf = test.receive_buffer();
+
+    expect(buf.size() >= 1);
+  };
+}
+
+void can_transceiver_receive_cursor_test() noexcept
+{
+  using namespace boost::ut;
+
+  "receive_cursor() returns initial cursor of zero"_test = [&]() {
+    test_can_transceiver test;
+
+    auto cursor = test.receive_cursor();
+
+    expect(that % 0 == cursor);
+  };
+
+  "receive_cursor() returns updated cursor value"_test = [&]() {
+    test_can_transceiver test;
+    test.rx_cursor = 3;
+
+    auto cursor = test.receive_cursor();
+
+    expect(that % 3 == cursor);
+  };
+
+  "receive_cursor() is within bounds of receive_buffer()"_test = [&]() {
+    test_can_transceiver test;
+    test.rx_cursor = 7;
+
+    auto cursor = test.receive_cursor();
+    auto buf = test.receive_buffer();
+
+    expect(cursor < buf.size());
+  };
+}
+
+void can_bus_manager_test() noexcept
+{
+  using namespace boost::ut;
+
+  "baud_rate() passes hertz to driver"_test = [&]() {
+    async::inplace_context<1024> ctx;
+    test_can_bus_manager test;
+
+    test.baud_rate(ctx, 250'000);
+
+    expect(250'000 == test.last_baud_rate);
+  };
+
+  "baud_rate() passes 1MHz to driver"_test = [&]() {
+    async::inplace_context<1024> ctx;
+    test_can_bus_manager test;
+
+    test.baud_rate(ctx, 1'000'000);
+
+    expect(1'000'000 == test.last_baud_rate);
+  };
+
+  "filter_mode() passes 'none' to driver"_test = [&]() {
+    async::inplace_context<1024> ctx;
+    test_can_bus_manager test;
+
+    test.filter_mode(ctx, hal::can_message_acceptance::none);
+
+    expect(hal::can_message_acceptance::none == test.last_filter_mode);
+  };
+
+  "filter_mode() passes 'all' to driver"_test = [&]() {
+    async::inplace_context<1024> ctx;
+    test_can_bus_manager test;
+
+    test.filter_mode(ctx, hal::can_message_acceptance::all);
+
+    expect(hal::can_message_acceptance::all == test.last_filter_mode);
+  };
+
+  "filter_mode() passes 'filtered' to driver"_test = [&]() {
+    async::inplace_context<1024> ctx;
+    test_can_bus_manager test;
+
+    test.filter_mode(ctx, hal::can_message_acceptance::filtered);
+
+    expect(hal::can_message_acceptance::filtered == test.last_filter_mode);
+  };
+
+  "on_bus_off() calls driver"_test = [&]() {
+    async::inplace_context<1024> ctx;
+    test_can_bus_manager test;
+
+    test.on_bus_off(ctx);
+
+    expect(test.on_bus_off_called);
+  };
+
+  "bus_on() calls driver"_test = [&]() {
+    async::inplace_context<1024> ctx;
+    test_can_bus_manager test;
+
+    test.bus_on(ctx);
+
+    expect(test.bus_on_called);
+  };
+}
+
+void can_interrupt_test() noexcept
+{
+  using namespace boost::ut;
+
+  "on_receive() calls driver"_test = [&]() {
+    async::inplace_context<1024> ctx;
+    test_can_interrupt test;
+
+    test.on_receive(ctx);
+
+    expect(test.on_receive_called);
+  };
+}
+
+void can_filter_test() noexcept
+{
+  using namespace boost::ut;
+
+  "can_id_filter allow() passes ID to driver"_test = [&]() {
+    async::inplace_context<1024> ctx;
+    test_can_filter<hal::u16> test;
+
+    test.allow(ctx, hal::u16{ 0x123 });
+
+    expect(test.last_allowed.has_value());
+    expect(that % hal::u16{ 0x123 } == test.last_allowed.value());
+  };
+
+  "can_id_filter allow() with nullopt clears filter"_test = [&]() {
+    async::inplace_context<1024> ctx;
+    test_can_filter<hal::u16> test;
+    test.allow(ctx, hal::u16{ 0x123 });
+
+    test.allow(ctx, std::nullopt);
+
+    expect(!test.last_allowed.has_value());
+  };
+
+  "can_mask_filter allow() passes mask criteria to driver"_test = [&]() {
+    async::inplace_context<1024> ctx;
+    test_can_filter<hal::can_mask> test;
+    hal::can_mask expected{ .id = 0x100, .mask = 0x7F0 };
+
+    test.allow(ctx, expected);
+
+    expect(test.last_allowed.has_value());
+    expect((expected == test.last_allowed.value()) >> fatal);
+  };
+
+  "can_mask_filter allow() with nullopt clears filter"_test = [&]() {
+    async::inplace_context<1024> ctx;
+    test_can_filter<hal::can_mask> test;
+    test.allow(ctx, hal::can_mask{ .id = 0x100, .mask = 0x7FF });
+
+    test.allow(ctx, std::nullopt);
+
+    expect(!test.last_allowed.has_value());
+  };
+
+  "can_range_filter allow() passes range to driver"_test = [&]() {
+    async::inplace_context<1024> ctx;
+    test_can_filter<hal::can_range> test;
+    hal::can_range expected{ .id_1 = 0x100, .id_2 = 0x1FF };
+
+    test.allow(ctx, expected);
+
+    expect(test.last_allowed.has_value());
+    expect((expected == test.last_allowed.value()) >> fatal);
+  };
+
+  "can_range_filter allow() with nullopt clears filter"_test = [&]() {
+    async::inplace_context<1024> ctx;
+    test_can_filter<hal::can_range> test;
+    test.allow(ctx, hal::can_range{ .id_1 = 0x100, .id_2 = 0x1FF });
+
+    test.allow(ctx, std::nullopt);
+
+    expect(!test.last_allowed.has_value());
+  };
+
+  "can_mask_ext_filter allow() passes extended mask criteria to driver"_test =
+    [&]() {
+      async::inplace_context<1024> ctx;
+      test_can_filter<hal::can_mask_ext> test;
+      hal::can_mask_ext expected{ .id = 0x1FFFF00, .mask = 0x1FFFFFF0 };
+
+      test.allow(ctx, expected);
+
+      expect(test.last_allowed.has_value());
+      expect((expected == test.last_allowed.value()) >> fatal);
+    };
+
+  "can_range_ext_filter allow() passes extended range to driver"_test = [&]() {
+    async::inplace_context<1024> ctx;
+    test_can_filter<hal::can_range_ext> test;
+    hal::can_range_ext expected{ .id_1 = 0x1000000, .id_2 = 0x1FFFFFFF };
+
+    test.allow(ctx, expected);
+
+    expect(test.last_allowed.has_value());
+    expect((expected == test.last_allowed.value()) >> fatal);
+  };
+}
+
+}  // namespace
+
+int main()
+{
+  can_message_equality_test();
+  can_transceiver_baud_rate_test();
+  can_transceiver_send_test();
+  can_transceiver_receive_buffer_test();
+  can_transceiver_receive_cursor_test();
+  can_bus_manager_test();
+  can_interrupt_test();
+  can_filter_test();
+}

--- a/v5/tests/can.test.cpp
+++ b/v5/tests/can.test.cpp
@@ -26,7 +26,7 @@ using namespace mp_units;
 using namespace mp_units::si::unit_symbols;
 
 namespace {
-class test_can_transceiver : public hal::can_transceiver
+class test_can_transceiver : public hal::awaitable_can_transceiver
 {
 public:
   hal::can_message last_sent_message{};
@@ -34,6 +34,7 @@ public:
   hal::usize rx_cursor{ 0 };
   hal::hertz baud_rate_hz{ 500'000 * Hz };
 
+  bool on_receive_called{ false };
   ~test_can_transceiver() override = default;
 
 private:
@@ -57,6 +58,11 @@ private:
   hal::usize driver_receive_cursor() override
   {
     return rx_cursor;
+  }
+  async::future<void> driver_on_receive(async::context&) override
+  {
+    on_receive_called = true;
+    return {};
   }
 };
 
@@ -95,21 +101,6 @@ private:
   async::future<void> driver_bus_on(async::context&) override
   {
     bus_on_called = true;
-    return {};
-  }
-};
-
-class test_can_interrupt : public hal::can_interrupt
-{
-public:
-  bool on_receive_called{ false };
-
-  ~test_can_interrupt() override = default;
-
-private:
-  async::future<void> driver_on_receive(async::context&) override
-  {
-    on_receive_called = true;
     return {};
   }
 };
@@ -428,7 +419,7 @@ void can_interrupt_test() noexcept
 
   "on_receive() calls driver"_test = [&]() {
     async::inplace_context<1024> ctx;
-    test_can_interrupt test;
+    test_can_transceiver test;
 
     test.on_receive(ctx);
 


### PR DESCRIPTION
Brings the CAN hardware abstraction interface from v4 to v5 with an
async/await redesign and improved filter architecture.

## Summary

- **Async/Coroutine Redesign**: All CAN operations now use `async::future` with
  async contexts instead of synchronous calls, enabling efficient coroutine-based
  I/O and multi-operation coordination.
- **Simplified Class Hierarchy**: Remove the monolithic v4 `can` interface
- **Generic Filter Template**: Replaces separate filter classes with a single
  `can_filter<T>` interface template and concrete type aliases (`can_id_filter`,
  `can_mask_filter`, `can_range_filter`, etc.), supporting both standard and
  extended identifiers.
- **Enhanced Message Types**: Introduces `can_mask` and `can_range` structs with
  three-way comparisons for flexible hardware-agnostic filtering configuration.
- **Buffer Management**: Utilized circular receive buffer with cursor-based
  notifications for efficient zero-copy message consumption, same as `hal::serial`.
- **Replace `can_interrupt` with `awaitable_can_transceiver`**: The analog to the `awaitable_serial`
