### PR TITLE
:sparkles: Add hal::pimpl CRTP type

### DIFF
--- a/v5/CMakeLists.txt
+++ b/v5/CMakeLists.txt
@@ -45,6 +45,7 @@ libhal_add_library(libhal
         modules/i2c.cppm
         modules/spi.cppm
         modules/serial.cppm
+        modules/memory.cppm
         modules/containers.cppm
 )
 
@@ -67,5 +68,5 @@ libhal_add_tests(libhal
         serial
         containers
         sensors
-        can
+        pimpl
 )

--- a/v5/conanfile.py
+++ b/v5/conanfile.py
@@ -97,7 +97,7 @@ class libhal_conan(ConanFile):
         self.tool_requires("libhal-cmake-util/[^5.0.7]")
 
     def requirements(self):
-        self.requires("strong_ptr/[^0.1.8]")
+        self.requires("strong_ptr/[^0.2.2]")
         self.requires("async_context/[^0.0.10]")
         self.requires("scatter_span/0.0.0")
         self.requires("mp-units/2.5.1@libhal",

--- a/v5/modules/aliases.cppm
+++ b/v5/modules/aliases.cppm
@@ -37,6 +37,6 @@ export using task = async::task;
 export template<typename T>
 using future_ptr = async::future<mem::strong_ptr<T>>;
 
-/// Shorthand for the allocator type accepted by ptr<T> factory functions.
+/// Shorthand for the allocator type
 export using allocator = std::pmr::polymorphic_allocator<>;
 }  // namespace hal::inline v5

--- a/v5/modules/hal.cppm
+++ b/v5/modules/hal.cppm
@@ -36,6 +36,10 @@ export import :steady_clock;
 export import :i2c;
 export import :spi;
 export import :serial;
+export import :servo;
+export import :motor;
+export import :memory;
+export import :containers;
 export import :usb;
 
 export namespace hal::inline v5 {

--- a/v5/modules/memory.cppm
+++ b/v5/modules/memory.cppm
@@ -1,0 +1,179 @@
+// Copyright 2026 Khalil Estell and the libhal contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module;
+
+#include <memory_resource>
+#include <type_traits>
+
+export module hal:memory;
+
+import strong_ptr;
+import async_context;
+
+namespace hal::inline v5 {
+
+/// Polymorphic allocator for dynamic memory allocation
+///
+/// A `std::pmr::polymorphic_allocator<>` that enables flexible memory resource
+/// management. Can be configured to use custom memory resources for different
+/// allocation strategies (arena, monotonic, unsynchronize, etc).
+export using allocator = std::pmr::polymorphic_allocator<>;
+
+/// Strong pointer with shared ownership and automatic cleanup
+///
+/// A reference-counted smart pointer that automatically deletes the managed
+/// object when the last pointer to it is destroyed. Thread-safe and moveable.
+/// @tparam T The type of object being managed
+export template<class T>
+using ptr = mem::strong_ptr<T>;
+
+/// Optional strong pointer that may be null
+///
+/// A nullable reference-counted smart pointer combining the benefits of
+/// optional and strong_ptr. Useful for optional owning references.
+/// @tparam T The type of object being managed
+export template<class T>
+using opt_ptr = mem::optional_ptr<T>;
+
+export template<class T = void>
+using future = async::future<T>;
+
+/// Async factory result for a managed object
+///
+/// A future that resolves to a strong_ptr. Used for factory functions that
+/// perform async initialization. The caller co_awaits the factory and receives
+/// a strong_ptr to the fully initialized object.
+/// @tparam T The type of object being created asynchronously
+export template<class T>
+using future_ptr = future<hal::ptr<T>>;
+
+/// Create a managed object with a strong pointer
+///
+/// Allocates and constructs a new object with the given allocator,
+/// returning a strong_ptr that manages its lifetime.
+/// @tparam T The type of object to create
+/// @tparam Args Parameter types forwarded to T's constructor
+/// @param p_allocator The polymorphic allocator to use for allocation
+/// @param p_args Arguments forwarded to T's constructor
+/// @return A strong_ptr managing the newly created object
+export template<class T, class... Args>
+ptr<T> allocate(allocator p_allocator, Args&&... p_args)
+{
+  return mem::make_strong_ptr<T>(p_allocator, p_args...);
+}
+
+/// Create a static-duration managed object with a strong pointer
+///
+/// Creates a static object and returns a strong_ptr wrapping it.
+/// The object persists for the entire program duration and is never deleted.
+/// The unique_key template parameter enables multiple static instances of
+/// the same type by providing different lambda keys.
+/// @tparam T The type of object to create
+/// @tparam Args Parameter types forwarded to T's constructor
+/// @tparam unique_key A unique lambda to allow multiple static instances
+/// @param p_args Arguments forwarded to T's constructor
+/// @return A strong_ptr managing the static object
+export template<class T, class... Args, auto unique_key = []() {}>
+mem::strong_ptr<T> static_allocate(Args... p_args)
+{
+  static T object(p_args...);
+  return mem::strong_ptr<T>(mem::unsafe_assume_static_tag{}, object);
+}
+
+/// Enable Pimpl (Private Implementation) pattern for hiding implementation
+///
+/// Base class for implementing the Pimpl idiom, commonly used by manager
+/// objects that own hardware or resources. Hides platform-specific or
+/// complex implementation details in a private `impl` struct. Derives from
+/// enable_strong_from_this to allow the impl to obtain pointers back to
+/// the manager. The derived class must define a nested `impl` type.
+/// @tparam Derived The derived manager class implementing Pimpl
+/// @note Define a nested `struct impl` in the .cpp file only. Call
+///       initialize_pimpl(allocator, ...) in the constructor to allocate
+///       and initialize the impl object. Use impl() to access it.
+export template<typename Derived>
+class pimpl
+{
+protected:
+  using destroy_fn_t = void(void*, allocator) noexcept;
+
+  static consteval bool needs_destruction()
+  {
+    return not std::is_trivially_destructible_v<typename Derived::impl>;
+  }
+
+  /// Access the mutable implementation object
+  ///
+  /// Returns a reference to the implementation struct allocated by
+  /// initialize_pimpl(). Used in public methods of the derived class
+  /// to access hardware state and configuration.
+  [[nodiscard]] auto& inner() noexcept
+  {
+    return *static_cast<typename Derived::impl*>(m_impl);
+  }
+
+  /// Access the immutable implementation object
+  ///
+  /// Const version of inner(). Used in const methods of the derived class.
+  [[nodiscard]] auto const& inner() const noexcept
+  {
+    return *static_cast<typename Derived::impl const*>(m_impl);
+  }
+
+  /// Initialize the implementation object with custom allocator
+  ///
+  /// Allocates and constructs the impl struct using the provided allocator
+  /// and constructor arguments. Must be called exactly once in the derived
+  /// class constructor. The impl object is automatically destroyed when
+  /// the manager is destroyed.
+  /// @param p_resource The allocator to use for impl allocation
+  /// @param p_args Arguments forwarded to the impl struct constructor
+  /// @note Call this from the derived class constructor before any
+  ///       other operations that access impl()
+  template<typename... Args>
+  pimpl(allocator p_allocator, Args&&... p_args)
+    : m_allocator(p_allocator.resource())
+  {
+    using impl_type = typename Derived::impl;
+    m_impl = p_allocator.new_object<impl_type>(std::forward<Args>(p_args)...);
+  }
+
+  ~pimpl() noexcept
+  {
+    // This check exists in the event that `initialize_pimpl` was never called
+    if constexpr (needs_destruction()) {
+      if (m_impl != nullptr) {
+        using impl_type = typename Derived::impl;
+        allocator(m_allocator).delete_object(static_cast<impl_type*>(m_impl));
+      }
+    }
+  }
+
+private:
+  friend Derived;
+  struct private_key
+  {
+    friend Derived;
+
+  private:
+    private_key() = default;
+  };
+
+  pimpl() = default;
+
+  std::pmr::memory_resource* m_allocator;
+  void* m_impl = nullptr;
+};
+}  // namespace hal::inline v5

--- a/v5/modules/units.cppm
+++ b/v5/modules/units.cppm
@@ -53,8 +53,8 @@ using i8 = std::int8_t;
 using i16 = std::int16_t;
 using i32 = std::int32_t;
 using i64 = std::int64_t;
-using isize = std::uintptr_t;
-using iptr = std::uintptr_t;
+using isize = std::intptr_t;
+using iptr = std::intptr_t;
 
 using common_rep_t = float;
 

--- a/v5/tests/pimpl.test.cpp
+++ b/v5/tests/pimpl.test.cpp
@@ -1,0 +1,227 @@
+#include <algorithm>
+#include <coroutine>
+#include <memory_resource>
+#include <print>
+#include <span>
+#include <thread>
+#include <vector>
+
+#include <boost/ut.hpp>
+
+import hal;
+import strong_ptr;
+
+bool smart_motor_exists = false;
+
+class tracking_allocator : public std::pmr::memory_resource
+{
+public:
+  explicit tracking_allocator(
+    std::pmr::memory_resource* p_upstream = std::pmr::new_delete_resource())
+    : m_upstream(p_upstream)
+  {
+  }
+
+  struct record
+  {
+    void* ptr;
+    std::size_t bytes;
+  };
+
+  bool deallocate_called = false;
+  hal::usize allocate_count = 0;
+  hal::usize deallocate_count = 0;
+  void* last_allocated_ptr = nullptr;
+  void* last_deallocated_ptr = nullptr;
+  std::size_t last_allocated_bytes = 0;
+  std::size_t last_deallocated_bytes = 0;
+  std::vector<record> allocations;
+  std::vector<record> deallocations;
+
+  [[nodiscard]] bool was_deallocated(void* p_ptr, std::size_t p_bytes) const
+  {
+    return std::ranges::any_of(deallocations, [&](record const& p_record) {
+      return p_record.ptr == p_ptr && p_record.bytes == p_bytes;
+    });
+  }
+
+private:
+  void* do_allocate(std::size_t p_bytes, std::size_t p_alignment) override
+  {
+    allocate_count++;
+    last_allocated_bytes = p_bytes;
+    last_allocated_ptr = m_upstream->allocate(p_bytes, p_alignment);
+    allocations.push_back({ last_allocated_ptr, p_bytes });
+    return last_allocated_ptr;
+  }
+
+  void do_deallocate(void* p_ptr,
+                     std::size_t p_bytes,
+                     std::size_t p_alignment) override
+  {
+    deallocate_called = true;
+    deallocate_count++;
+    last_deallocated_ptr = p_ptr;
+    last_deallocated_bytes = p_bytes;
+    deallocations.push_back({ p_ptr, p_bytes });
+    m_upstream->deallocate(p_ptr, p_bytes, p_alignment);
+  }
+
+  [[nodiscard]] bool do_is_equal(
+    std::pmr::memory_resource const& p_other) const noexcept override
+  {
+    return this == &p_other;
+  }
+
+  std::pmr::memory_resource* m_upstream;
+};
+
+class smart_motor : public hal::pimpl<smart_motor>
+{
+public:
+  struct impl;  // forward declaration only
+
+  // Create Factory Function
+  static async::future<hal::ptr<smart_motor>> create(
+    async::context&,
+    hal::allocator p_allocator,
+    hal::ptr<hal::awaitable_serial> const& p_serial);
+
+  // Position rotation with velocity + torque control
+  static async::future<hal::ptr<hal::veltor_servo>> acquire_veltor_servo(
+    async::context&,
+    hal::allocator);
+
+  // Continuous rotation with velocity + torque control
+  static async::future<hal::ptr<hal::motor>> acquire_motor(async::context&);
+
+  // Must start with `acquire_` and should either be name of interface or
+  // something descriptive like `acquire_rear_left_motor`.
+
+  smart_motor(private_key,
+              hal::allocator p_allocator,
+              hal::ptr<hal::awaitable_serial> const& p_serial);
+
+  ~smart_motor()
+  {
+    smart_motor_exists = false;
+  }
+};
+
+// in impl file
+struct smart_motor::impl
+{
+  hal::ptr<hal::awaitable_serial> serial;
+  hal::u8 address = 0;
+};
+
+smart_motor::smart_motor(private_key,
+                         hal::allocator p_allocator,
+                         hal::ptr<hal::awaitable_serial> const& p_serial)
+  : pimpl(p_allocator, smart_motor::impl{ .serial = p_serial, .address = 0 })
+{
+  smart_motor_exists = true;
+  std::println("Hello, World!");
+}
+
+async::future<hal::ptr<smart_motor>> smart_motor::create(
+  [[maybe_unused]] async::context& p_ctx,
+  hal::allocator p_allocator,
+  hal::ptr<hal::awaitable_serial> const& p_serial)
+{
+  return hal::allocate<smart_motor>(
+    p_allocator, private_key{}, p_allocator, p_serial);
+}
+
+class test_awaitable_serial : public hal::awaitable_serial
+{
+public:
+  static hal::ptr<test_awaitable_serial> create(hal::allocator p_allocator)
+  {
+    return hal::allocate<test_awaitable_serial>(p_allocator);
+  }
+
+  hal::serial::settings configured_settings{};
+  std::array<hal::byte, 256> last_data_out{};
+  hal::usize last_data_out_size{};
+  std::array<hal::byte, 256> rx_buffer{};
+  hal::usize rx_cursor{ 0 };
+  hal::serial_event last_event{};
+  bool wait_for_called{ false };
+
+  ~test_awaitable_serial() override = default;
+
+private:
+  async::future<void> driver_configure(
+    async::context&,
+    hal::serial::settings const& p_settings) override
+  {
+    configured_settings = p_settings;
+    return {};
+  }
+
+  async::future<void> driver_write(
+    async::context&,
+    mem::scatter_span<hal::byte const> p_data) override
+  {
+    last_data_out_size = 0;
+    for (auto const& span : p_data) {
+      for (auto byte : span) {
+        if (last_data_out_size >= last_data_out.size()) {
+          break;
+        }
+        last_data_out[last_data_out_size] = byte;
+        last_data_out_size++;
+      }
+    }
+    return {};
+  }
+
+  hal::circular_span<hal::byte const> driver_receive_buffer() override
+  {
+    return rx_buffer;
+  }
+
+  hal::usize driver_receive_cursor() override
+  {
+    return rx_cursor;
+  }
+
+  async::future<void> driver_wait_for(async::context&,
+                                      hal::serial_event p_event) override
+  {
+    last_event = p_event;
+    wait_for_called = true;
+    return {};
+  }
+};
+
+int main()
+{
+  tracking_allocator tracker;
+  hal::allocator alloc{ &tracker };
+  auto serial = test_awaitable_serial::create(alloc);
+  async::inplace_context<1024> ctx;
+  using namespace boost::ut;
+
+  auto const allocations_before_create = tracker.allocations.size();
+  std::vector<tracking_allocator::record> motor_allocations;
+  {
+    auto motor = smart_motor::create(ctx, alloc, serial);
+    motor_allocations.assign(
+      tracker.allocations.begin() +
+        static_cast<std::ptrdiff_t>(allocations_before_create),
+      tracker.allocations.end());
+
+    expect(that % smart_motor_exists);
+    expect(that % not tracker.deallocate_called);
+    expect(that % tracker.last_deallocated_ptr == nullptr);
+    expect(that % tracker.last_deallocated_bytes == 0);
+  }
+  expect(that % not smart_motor_exists);
+  expect(that % tracker.deallocate_called);
+  expect(that % not motor_allocations.empty());
+  for (auto const& allocation : motor_allocations) {
+    expect(that % tracker.was_deallocated(allocation.ptr, allocation.bytes));
+  }
+}


### PR DESCRIPTION
Introduce hal::pimpl<Derived>, a CRTP base for the pimpl idiom that allocates and owns a hidden impl struct via a polymorphic allocator.

Add a pimpl.test.cpp covering a smart_motor example, using a custom tracking_allocator (std::pmr::memory_resource) to verify that both the object's own allocation and its impl allocation are deallocated when the object is destroyed.